### PR TITLE
Fix master node authentication handshake

### DIFF
--- a/CPCluster_masterNode/src/main.rs
+++ b/CPCluster_masterNode/src/main.rs
@@ -73,6 +73,11 @@ async fn handle_connection(
     if received_token == token {
         println!("Client authenticated with correct token");
 
+        // Inform the client that authentication succeeded so it can
+        // continue with the protocol. Without this message the client
+        // would block waiting for a response.
+        socket.write_all(b"OK").await?;
+
         // Füge die Node zur verbundenen Liste hinzu
         master_node.connected_nodes.lock().unwrap().insert(addr.clone(), addr.clone());
 


### PR DESCRIPTION
## Summary
- send success message from the master node after authentication

## Testing
- `cargo check --manifest-path CPCluster_masterNode/Cargo.toml`
- `cargo check --manifest-path CPCluster_node/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_6849c0fa924083258fbf7ab3d843a399