### PR TITLE
Add container setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ CPCluster is a distributed network of nodes that communicate with each other for
    You can run `scripts/install.sh` from the repository root to install Rust
    (if missing) and build both projects automatically.
 
+   For a full container setup including system packages you can also run
+   `./setup_container.sh` from the repository root. This installs required
+   packages, Rust and builds both crates.
+
 2. **Navigate to each project**:
    - Master Node:
      ```bash

--- a/setup_container.sh
+++ b/setup_container.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Setup script for CPCluster development container
+set -e
+
+# Install system packages
+sudo apt-get update
+sudo apt-get install -y curl git build-essential pkg-config libssl-dev
+
+# Install Rust if not already installed
+if ! command -v cargo >/dev/null 2>&1; then
+    echo "Rust not found. Installing via rustup..."
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+    source "$HOME/.cargo/env"
+else
+    echo "Rust is already installed"
+fi
+
+# Build master and node crates
+for dir in CPCluster_masterNode CPCluster_node; do
+    echo "Building $dir..."
+    (cd "$dir" && cargo build --release)
+    echo "Finished building $dir"
+done
+
+echo "Setup complete. Use 'cargo run' in each directory to start the master or node."


### PR DESCRIPTION
## Summary
- add `setup_container.sh` to install dependencies inside a container
- document the new script in the README

## Testing
- `cargo build -q && echo "MASNODE_BUILD_OK" > /tmp/masternode_build.log`
- `cargo build -q && echo "NODE_BUILD_OK" > /tmp/node_build.log`


------
https://chatgpt.com/codex/tasks/task_e_6849c433803c8325bc485528bae232ab