### PR TITLE
Refactor message types into shared crate

### DIFF
--- a/CPCluster_masterNode/Cargo.toml
+++ b/CPCluster_masterNode/Cargo.toml
@@ -11,3 +11,4 @@ rustls-pemfile = "0.2.1"  # Fügen Sie diese Zeile hinzu
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 uuid = { version = "1.0", features = ["v4"] }
+cpcluster_common = { path = "../cpcluster_common" }

--- a/CPCluster_masterNode/src/main.rs
+++ b/CPCluster_masterNode/src/main.rs
@@ -1,5 +1,5 @@
 use std::{collections::{HashMap, HashSet}, error::Error, fs, sync::{Arc, Mutex}};
-use serde::{Deserialize, Serialize};
+use cpcluster_common::{JoinInfo, NodeMessage};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use uuid::Uuid;
@@ -7,27 +7,12 @@ use uuid::Uuid;
 const MIN_PORT: u16 = 55001;
 const MAX_PORT: u16 = 55999;
 
-#[derive(Serialize, Deserialize)]
-struct JoinInfo {
-    token: String,
-    ip: String,
-    port: String,
-}
-
 #[derive(Debug, Clone)]
 struct MasterNode {
     connected_nodes: Arc<Mutex<HashMap<String, String>>>, // speichert Node-ID und IP-Adresse
     available_ports: Arc<Mutex<HashSet<u16>>>,            // verwaltet verfügbare Ports
 }
 
-#[derive(Serialize, Deserialize, Debug)]
-enum NodeMessage {
-    RequestConnection(String),   // Anfrage, sich mit einer anderen Node zu verbinden
-    ConnectionInfo(String, u16), // Verbindungsinfo: Ziel-IP und Port
-    GetConnectedNodes,           // Anforderung für die Liste verbundener Nodes
-    ConnectedNodes(Vec<String>), // Antwort mit der Liste verbundener Nodes
-    Disconnect,                  // Nachricht zum Beenden der Verbindung
-}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {

--- a/CPCluster_node/Cargo.toml
+++ b/CPCluster_node/Cargo.toml
@@ -22,3 +22,4 @@ serde_json = "1.0"
 
 # UUID für eindeutige Aufgaben-IDs
 uuid = { version = "1", features = ["v4"] }
+cpcluster_common = { path = "../cpcluster_common" }

--- a/CPCluster_node/src/main.rs
+++ b/CPCluster_node/src/main.rs
@@ -1,22 +1,6 @@
 use std::{error::Error, fs};
-use serde::{Deserialize, Serialize};
+use cpcluster_common::{JoinInfo, NodeMessage};
 use tokio::{net::TcpStream, io::{AsyncReadExt, AsyncWriteExt}};
-
-#[derive(Serialize, Deserialize)]
-struct JoinInfo {
-    token: String,
-    ip: String,
-    port: String,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-enum NodeMessage {
-    RequestConnection(String),
-    ConnectionInfo(String, u16),
-    GetConnectedNodes,
-    ConnectedNodes(Vec<String>),
-    Disconnect,
-}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,6 @@
+[workspace]
+members = [
+    "CPCluster_masterNode",
+    "CPCluster_node",
+    "cpcluster_common"
+]

--- a/cpcluster_common/Cargo.toml
+++ b/cpcluster_common/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "cpcluster_common"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }

--- a/cpcluster_common/src/lib.rs
+++ b/cpcluster_common/src/lib.rs
@@ -1,0 +1,17 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+pub struct JoinInfo {
+    pub token: String,
+    pub ip: String,
+    pub port: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub enum NodeMessage {
+    RequestConnection(String),
+    ConnectionInfo(String, u16),
+    GetConnectedNodes,
+    ConnectedNodes(Vec<String>),
+    Disconnect,
+}


### PR DESCRIPTION
## Summary
- add `cpcluster_common` library crate for shared structures
- move `JoinInfo` and `NodeMessage` definitions into `cpcluster_common`
- set up workspace with a new root `Cargo.toml`
- use the shared types in both binaries and add the new crate as a dependency

## Testing
- `cargo check --workspace`

------
https://chatgpt.com/codex/tasks/task_e_6849c68ff4f48325901ea416da9f4d93