### PR TITLE
Add reconnect handling to node heartbeats

### DIFF
--- a/CPCluster_node/src/main.rs
+++ b/CPCluster_node/src/main.rs
@@ -34,6 +34,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let config = Config::load("config.json").unwrap_or_default();
 
     let mut stream: Option<Box<dyn ReadWrite + Unpin + Send>> = None;
+    let mut open_tasks: Vec<NodeMessage> = Vec::new();
     for addr in &config.master_addresses {
         match connect(addr, isLocalIp(&joinInfo.ip), &joinInfo.ip).await {
             Ok(s) => {
@@ -89,7 +90,16 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     loop {
         if let Err(e) = sendMessage(&mut stream, NodeMessage::Heartbeat).await {
             println!("Heartbeat failed: {}", e);
-            break;
+            match reconnect(&joinInfo, &config, &open_tasks).await {
+                Ok(s) => {
+                    stream = s;
+                    continue;
+                }
+                Err(err) => {
+                    println!("Reconnect failed: {}", err);
+                    break;
+                }
+            }
         }
         tokio::time::sleep(std::time::Duration::from_millis(config.failover_timeout_ms)).await;
     }
@@ -133,4 +143,59 @@ async fn connect(
         let tls = connector.connect(serverName, tcp).await?;
         Ok(Box::new(tls))
     }
+}
+
+async fn reconnect(
+    join_info: &JoinInfo,
+    config: &Config,
+    open_tasks: &[NodeMessage],
+) -> Result<Box<dyn ReadWrite + Unpin + Send>, Box<dyn Error + Send + Sync>> {
+    for addr in &config.master_addresses {
+        match connect(addr, isLocalIp(&join_info.ip), &join_info.ip).await {
+            Ok(mut s) => {
+                println!("Reconnected to Master Node at {}", addr);
+
+                // re-authenticate
+                s.write_all(join_info.token.as_bytes()).await?;
+                let mut auth_resp = vec![0; 1024];
+                let n = s.read(&mut auth_resp).await?;
+                if n == 0 || &auth_resp[..n] == b"Invalid token" {
+                    println!("Authentication failed during reconnect");
+                    continue;
+                }
+                println!("Re-authentication successful");
+
+                // request nodes again
+                if let Err(e) = sendMessage(&mut s, NodeMessage::GetConnectedNodes).await {
+                    println!("Failed to request connected nodes: {}", e);
+                } else {
+                    let mut buf = vec![0; 1024];
+                    if let Ok(n) = s.read(&mut buf).await {
+                        if n > 0 {
+                            if let Ok(NodeMessage::ConnectedNodes(nodes)) = serde_json::from_slice(&buf[..n]) {
+                                println!("Currently connected nodes in the network: {:?}", nodes);
+                            }
+                        }
+                    }
+                }
+
+                // resend open tasks
+                for task in open_tasks {
+                    if let Err(e) = sendMessage(&mut s, task.clone()).await {
+                        println!("Failed to resend task: {}", e);
+                    }
+                }
+
+                return Ok(s);
+            }
+            Err(e) => {
+                println!("Failed to connect to {}: {}", addr, e);
+            }
+        }
+    }
+
+    Err(Box::new(std::io::Error::new(
+        std::io::ErrorKind::Other,
+        "Unable to reconnect to any master node",
+    )))
 }

--- a/cpcluster_common/src/lib.rs
+++ b/cpcluster_common/src/lib.rs
@@ -10,7 +10,7 @@ pub struct JoinInfo {
     pub port: String,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum NodeMessage {
     RequestConnection(String),
     ConnectionInfo(String, u16),


### PR DESCRIPTION
## Summary
- derive `Clone` for `NodeMessage`
- reconnect to master node when heartbeats fail
- send new authentication and resend any queued tasks on reconnect

## Testing
- `cargo check --all --quiet`
- `cargo test --all --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6849dcc6b4888325ae0d85425725f398