### PR TITLE
Add task creation command to master shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,16 @@ CPCluster is a distributed network of nodes that communicate with each other for
 4. **Handling Disconnection**:
    - If a node disconnects, the master releases the assigned port for future connections and notifies the other node if necessary.
 
+### Master Shell
+
+When the master node starts it opens an interactive shell. Besides `nodes` and
+`tasks` you can queue new work with `addtask`:
+
+```bash
+addtask compute 1+2
+addtask http https://example.com
+```
+
 ## Code Structure
 
 ### Master Node (`CPCluster_masterNode/src/main.rs`)


### PR DESCRIPTION
## Summary
- extend master shell help output
- add `addtask` shell command for creating simple tasks
- document shell usage in README

## Testing
- `cargo check --workspace`

------
https://chatgpt.com/codex/tasks/task_e_684b2f5efc2c8325887253f210f7d5bd