### PR TITLE
Add task results retrieval to shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,21 @@ CPCluster is a distributed network of nodes that communicate with each other for
 4. **Handling Disconnection**:
    - If a node disconnects, the master releases the assigned port for future connections and notifies the other node if necessary.
 
+### Master Shell
+
+When the master node starts it opens an interactive shell. Besides `nodes` and
+`tasks` you can queue new work with `addtask`. Use `results` to list completed
+tasks and `result <id>` to print a single outcome:
+
+```bash
+addtask compute 1+2
+addtask http https://example.com
+
+# Later you can check finished tasks
+results
+result <task-id>
+```
+
 ## Code Structure
 
 ### Master Node (`CPCluster_masterNode/src/main.rs`)


### PR DESCRIPTION
## Summary
- track task results in the master state
- print finished task results via new `results` and `result` shell commands
- document how to view task results in the README

## Testing
- `cargo check --workspace`


------
https://chatgpt.com/codex/tasks/task_e_684b2f5efc2c8325887253f210f7d5bd