### PR TITLE
Add task status query to CPCluster master shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ CPCluster is a distributed network of nodes that communicate with each other for
 ### Master Shell
 
 When the master node starts it opens an interactive shell. Besides `nodes` and
-`tasks` you can queue new work with `addtask`:
+`tasks` you can check the status of a specific job with `task <id>` or queue new
+work with `addtask`:
 
 ```bash
 addtask compute 1+2


### PR DESCRIPTION
## Summary
- track completed tasks in the master node
- persist completed tasks in `master_state.json`
- add `task <id>` command to the master shell
- show completed tasks when listing tasks
- document new command in the README

## Testing
- `cargo fmt`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684b335c7d6883258745e0c1a30d33bc