### PR TITLE
Use Error::other and fix clippy warnings

### DIFF
--- a/CPCluster_masterNode/src/main.rs
+++ b/CPCluster_masterNode/src/main.rs
@@ -179,7 +179,7 @@ fn run_shell(master: Arc<MasterNode>) {
                     }
                 }
                 cmd if cmd.trim_start().starts_with("task") => {
-                    let parts: Vec<&str> = cmd.trim().split_whitespace().collect();
+                    let parts: Vec<&str> = cmd.split_whitespace().collect();
                     if parts.len() != 2 {
                         println!("Usage: task <id>");
                     } else {
@@ -203,7 +203,7 @@ fn run_shell(master: Arc<MasterNode>) {
                     }
                 }
                 cmd if cmd.trim_start().starts_with("addtask") => {
-                    let parts: Vec<&str> = cmd.trim().splitn(3, ' ').collect();
+                    let parts: Vec<&str> = cmd.splitn(3, ' ').collect();
                     if parts.len() < 3 {
                         println!("Usage: addtask compute <expression> | addtask http <url>");
                     } else {
@@ -234,7 +234,7 @@ fn run_shell(master: Arc<MasterNode>) {
                     exit_shell = true;
                     break;
                 }
-                cmd if cmd.is_empty() => {}
+                "" => {}
                 _ => println!("Unknown command"),
             }
             if exit_shell {
@@ -258,7 +258,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let token = generate_token();
     let addr = config
         .master_addresses
-        .get(0)
+        .first()
         .cloned()
         .unwrap_or_else(|| "127.0.0.1:55000".to_string());
     let mut parts = addr.split(':');

--- a/CPCluster_node/src/main.rs
+++ b/CPCluster_node/src/main.rs
@@ -299,8 +299,7 @@ async fn reconnect(
         }
     }
 
-    Err(Box::new(std::io::Error::new(
-        std::io::ErrorKind::Other,
+    Err(Box::new(std::io::Error::other(
         "Unable to reconnect to any master node",
     )))
 }

--- a/cpcluster_common/src/config.rs
+++ b/cpcluster_common/src/config.rs
@@ -32,7 +32,7 @@ impl Config {
     pub fn load(path: &str) -> std::io::Result<Self> {
         match fs::read_to_string(path) {
             Ok(data) => serde_json::from_str(&data)
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e)),
+                .map_err(std::io::Error::other),
             Err(_) => Ok(Config::default()),
         }
     }


### PR DESCRIPTION
## Summary
- use `std::io::Error::other` when loading config
- fix clippy warnings in master and node crates

## Testing
- `cargo clippy --workspace -- -D warnings`

------
https://chatgpt.com/codex/tasks/task_e_684bd580eab48325984801b1901e9f7c