### PR TITLE
Include common crate in CI matrix

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,7 @@ jobs:
         project:
           - CPCluster_masterNode
           - CPCluster_node
+          - cpcluster_common
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- include `cpcluster_common` in workflow build matrix

## Testing
- `cargo test -p cpcluster_common`
- `cargo test -p cpcluster_masternode`
- `cargo test -p cpcluster_node`
- `act pull_request -j build_and_test -v` *(fails: no Docker in container)*

------
https://chatgpt.com/codex/tasks/task_e_684bd802d5488325a042be29b2f41c13