### PR TITLE
Update JoinInfo port type

### DIFF
--- a/CPCluster_masterNode/src/main.rs
+++ b/CPCluster_masterNode/src/main.rs
@@ -269,17 +269,17 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .unwrap_or_else(|| "127.0.0.1:55000".to_string());
     let mut parts = addr.split(':');
     let ip = parts.next().unwrap_or("127.0.0.1").to_string();
-    let port = parts.next().unwrap_or("55000").to_string();
+    let port: u16 = parts.next().unwrap_or("55000").parse().unwrap_or(55000);
 
     let join_info = JoinInfo {
         token: token.clone(),
         ip: ip.clone(),
-        port: port.clone(),
+        port,
     };
     fs::write("join.json", serde_json::to_string_pretty(&join_info)?)?;
     info!("Join information saved to join.json");
 
-    let listener = TcpListener::bind(format!("{}:{}", ip, port)).await?;
+    let listener = TcpListener::bind((ip.as_str(), port)).await?;
     info!("Master Node listening on {}:{}", ip, port);
 
     // prepare TLS acceptor using configured or self-signed certificate

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ addtask http https://example.com
 {
   "token": "your-unique-token-here",
   "ip": "127.0.0.1",
-  "port": "55000"
+  "port": 55000
 }
 ```
 

--- a/cpcluster_client/src/main.rs
+++ b/cpcluster_client/src/main.rs
@@ -11,7 +11,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     env_logger::init();
     let join_info: JoinInfo = serde_json::from_str(&fs::read_to_string("join.json")?)?;
     let addr = format!("{}:{}", join_info.ip, join_info.port);
-    let mut stream = TcpStream::connect(addr).await?;
+    let mut stream = TcpStream::connect(&addr).await?;
 
     write_length_prefixed(&mut stream, join_info.token.as_bytes()).await?;
     let resp = read_length_prefixed(&mut stream).await?;

--- a/cpcluster_common/README.md
+++ b/cpcluster_common/README.md
@@ -4,7 +4,7 @@
 
 ## Provided Types
 
-- `JoinInfo` – contains the authentication token and address information published by the master in `join.json`.
+- `JoinInfo` – contains the authentication token and address information (IP and numerical port) published by the master in `join.json`.
 - `NodeMessage` – enum describing messages exchanged over TCP:
   - `RequestConnection(String)` – ask the master to connect to another node.
   - `ConnectionInfo(String, u16)` – master response giving target IP and port.

--- a/cpcluster_common/src/lib.rs
+++ b/cpcluster_common/src/lib.rs
@@ -10,7 +10,7 @@ use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 pub struct JoinInfo {
     pub token: String,
     pub ip: String,
-    pub port: String,
+    pub port: u16,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]


### PR DESCRIPTION
## Summary
- use `u16` for `JoinInfo` `port`
- adjust master node to parse and bind numeric port
- update client to connect using numeric port
- refresh docs and example `join.json`

## Testing
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684bdb5ec79c8325807305a64d150ad0