### PR TITLE
Remove unused crate imports

### DIFF
--- a/cpcluster_client/src/main.rs
+++ b/cpcluster_client/src/main.rs
@@ -3,8 +3,6 @@ use std::{borrow::Cow, error::Error, fs};
 use tokio::net::TcpStream;
 use uuid::Uuid;
 use tokio::time::{sleep, Duration};
-use serde_json;
-use env_logger;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {


### PR DESCRIPTION
## Summary
- clean up cpcluster_client main by removing redundant `use` statements

## Testing
- `cargo clippy --workspace -- -D warnings`
- `cargo build --workspace`


------
https://chatgpt.com/codex/tasks/task_e_684bde47e6c88325bf5b4a2d29e4d52f