### PR TITLE
Ensure all crates build in setup script

### DIFF
--- a/setup_container.sh
+++ b/setup_container.sh
@@ -37,8 +37,8 @@ else
     echo "Rust is already installed"
 fi
 
-# Build master and node crates
-for dir in CPCluster_masterNode CPCluster_node; do
+# Build all crates so they are ready for use
+for dir in cpcluster_common cpcluster_client CPCluster_masterNode CPCluster_node; do
     echo "Building $dir..."
     (cd "$dir" && cargo build --release)
     echo "Finished building $dir"


### PR DESCRIPTION
## Summary
- build all project crates in `setup_container.sh`

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684bde647f88832591ee48b7bb1a3a3d