### PR TITLE
Handle config save errors

### DIFF
--- a/CPCluster_masterNode/src/main.rs
+++ b/CPCluster_masterNode/src/main.rs
@@ -259,7 +259,7 @@ fn run_shell(master: Arc<MasterNode>) {
 async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     env_logger::init();
     let config = Config::load("config.json").unwrap_or_default();
-    config.save("config.json").ok();
+    config.save("config.json")?;
 
     let token = generate_token();
     let addr = config

--- a/cpcluster_common/src/config.rs
+++ b/cpcluster_common/src/config.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::fs;
+use std::{error::Error, fs};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Config {
@@ -31,13 +31,14 @@ impl Default for Config {
 impl Config {
     pub fn load(path: &str) -> std::io::Result<Self> {
         match fs::read_to_string(path) {
-            Ok(data) => serde_json::from_str(&data)
-                .map_err(std::io::Error::other),
+            Ok(data) => serde_json::from_str(&data).map_err(std::io::Error::other),
             Err(_) => Ok(Config::default()),
         }
     }
 
-    pub fn save(&self, path: &str) -> std::io::Result<()> {
-        fs::write(path, serde_json::to_string_pretty(self).unwrap())
+    pub fn save(&self, path: &str) -> Result<(), Box<dyn Error + Send + Sync>> {
+        let data = serde_json::to_string_pretty(self)?;
+        fs::write(path, data)?;
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- propagate serde_json errors instead of unwrapping
- update master node to handle config save failures

## Testing
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_684be101b93483258ee61e7aea2c3196