### PR TITLE
Add fmt and clippy steps to Rust workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,6 +35,14 @@ jobs:
       working-directory: ${{ matrix.project }}
       run: cargo build --verbose
 
+    - name: Check formatting for ${{ matrix.project }}
+      working-directory: ${{ matrix.project }}
+      run: cargo fmt -- --check
+
+    - name: Run clippy for ${{ matrix.project }}
+      working-directory: ${{ matrix.project }}
+      run: cargo clippy -- -D warnings
+
     - name: Run tests for ${{ matrix.project }}
       working-directory: ${{ matrix.project }}
       run: cargo test --verbose


### PR DESCRIPTION
## Summary
- add `cargo fmt` and `cargo clippy` checks in the Rust CI workflow
- format `cpcluster_client` to satisfy `cargo fmt`

## Testing
- `cargo build --quiet` for each crate
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test --verbose`

------
https://chatgpt.com/codex/tasks/task_e_684be4c0f46483258865bd005436f2d5