### PR TITLE
Fix TLS cert load error handling

### DIFF
--- a/CPCluster_node/src/main.rs
+++ b/CPCluster_node/src/main.rs
@@ -229,8 +229,14 @@ fn build_tls_config(
             })?;
         }
     } else {
-        let native = native_certs::load_native_certs().expect("could not load platform certs");
-        for cert in native {
+        let native = native_certs::load_native_certs();
+        if !native.errors.is_empty() {
+            return Err(Box::new(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("could not load platform certs: {:?}", native.errors),
+            )));
+        }
+        for cert in native.certs {
             root_store
                 .add(&rustls::Certificate(cert.as_ref().to_vec()))
                 .map_err(|e| {


### PR DESCRIPTION
## Summary
- avoid panic when loading native TLS certs
- propagate cert load errors in TLS config builder

## Testing
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684be4bd07088325bdd0c605472daf9e