### PR TITLE
Fix now_ms panic on invalid system time

### DIFF
--- a/CPCluster_masterNode/src/main.rs
+++ b/CPCluster_masterNode/src/main.rs
@@ -555,7 +555,7 @@ fn release_port(master_node: &MasterNode, addr: String) {
 fn now_ms() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .unwrap()
+        .unwrap_or_else(|_| Duration::from_secs(0))
         .as_millis() as u64
 }
 


### PR DESCRIPTION
## Summary
- handle `SystemTime::duration_since` errors gracefully when calculating milliseconds
- `cargo test --workspace`

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_684be4b94320832594bb1d78706e6720