### PR TITLE
Fix tasks command

### DIFF
--- a/CPCluster_masterNode/src/main.rs
+++ b/CPCluster_masterNode/src/main.rs
@@ -159,14 +159,15 @@ fn run_shell(master: Arc<MasterNode>, rt: Handle) {
                 }
                 "tasks" => {
                     let nodes = master.connected_nodes.blocking_lock();
-                    if nodes.is_empty() {
-                        println!("No active tasks");
-                    } else {
-                        for (addr, info) in nodes.iter() {
-                            for (id, task) in info.active_tasks.iter() {
-                                println!("{}: {} -> {:?}", addr, id, task);
-                            }
+                    let mut printed_active = false;
+                    for (addr, info) in nodes.iter() {
+                        for (id, task) in info.active_tasks.iter() {
+                            println!("{}: {} -> {:?}", addr, id, task);
+                            printed_active = true;
                         }
+                    }
+                    if !printed_active {
+                        println!("No active tasks");
                     }
                     drop(nodes);
                     let pending = master.pending_tasks.blocking_lock();


### PR DESCRIPTION
## Summary
- properly show `No active tasks` if there are nodes but none running tasks

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_684c0dd3cb688325b3cb3e3fb7722220