### PR TITLE
Add handlers for new tasks

### DIFF
--- a/cpcluster_client/Cargo.toml
+++ b/cpcluster_client/Cargo.toml
@@ -13,3 +13,4 @@ env_logger = "0.10"
 log = "0.4"
 reqwest = { version = "0.11", features = ["rustls-tls"] }
 meval = "0.2"
+once_cell = "1.19"

--- a/cpcluster_common/README.md
+++ b/cpcluster_common/README.md
@@ -23,10 +23,19 @@
     expression uses `Cow<'static, str>` so it can borrow a string slice or own
     the data.
   - `HttpRequest { url }` – perform a HTTP GET request.
+  - `TcpIo { addr, port, data }` – send bytes over TCP and return the response.
+  - `UdpIo { addr, port, data }` – send bytes over UDP.
+  - `ComplexMath { expression }` – evaluate a more expensive expression.
+  - `StoreData { key, data }` and `RetrieveData { key }` – work with in-memory
+    storage.
+  - `DiskWrite { path, data }` and `DiskRead { path }` – interact with the
+    filesystem.
 
 - `TaskResult` – returned from task execution:
   - `Number(f64)` – result of a computation.
   - `Response(String)` – body of an HTTP request.
+  - `Bytes(Vec<u8>)` – raw bytes returned from I/O.
+  - `Stored` – confirmation that data was stored.
   - `Error(String)` – task failed with this error.
 
 These types are `serde` serializable and are used by both the `cpcluster_masternode` and `cpcluster_node` crates.

--- a/cpcluster_common/src/lib.rs
+++ b/cpcluster_common/src/lib.rs
@@ -17,12 +17,38 @@ pub struct JoinInfo {
 pub enum Task {
     Compute { expression: Cow<'static, str> },
     HttpRequest { url: String },
+    /// Send data over a TCP connection and return the response bytes.
+    TcpIo {
+        addr: String,
+        port: u16,
+        data: Vec<u8>,
+    },
+    /// Send a UDP datagram and optionally receive a response.
+    UdpIo {
+        addr: String,
+        port: u16,
+        data: Vec<u8>,
+    },
+    /// Perform a complex mathematical computation.
+    ComplexMath { expression: Cow<'static, str> },
+    /// Store arbitrary bytes in memory under the given key.
+    StoreData { key: String, data: Vec<u8> },
+    /// Retrieve previously stored data by key.
+    RetrieveData { key: String },
+    /// Write bytes to disk at the given path.
+    DiskWrite { path: String, data: Vec<u8> },
+    /// Read bytes from disk at the given path.
+    DiskRead { path: String },
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum TaskResult {
     Number(f64),
     Response(String),
+    /// Raw bytes returned from an operation (e.g. TCP/UDP I/O or disk read).
+    Bytes(Vec<u8>),
+    /// Data was successfully stored in memory or on disk.
+    Stored,
     Error(String),
 }
 


### PR DESCRIPTION
## Summary
- implement TCP/UDP I/O, RAM and disk operations in node and client
- maintain per-node data store for `StoreData`/`RetrieveData`
- update client with same task handling

## Testing
- `cargo check -p cpcluster_common`
- `cargo test -p cpcluster_common`
- `cargo check -p cpcluster_node`
- `cargo check -p cpcluster_client`


------
https://chatgpt.com/codex/tasks/task_e_684c2af5a55083258c4206704c7ea3b9