### PR TITLE
Add advanced task handling to node

### DIFF
--- a/CPCluster_node/Cargo.toml
+++ b/CPCluster_node/Cargo.toml
@@ -24,6 +24,8 @@ serde_json = "1.0"
 uuid = { version = "1", features = ["v4"] }
 reqwest = { version = "0.11", features = ["rustls-tls"] }
 meval = "0.2"
+num-complex = "0.4"
+once_cell = "1.17"
 cpcluster_common = { path = "../cpcluster_common" }
 rustls-native-certs = "0.8"
 log = "0.4"
@@ -31,3 +33,4 @@ env_logger = "0.10"
 
 [dev-dependencies]
 rcgen = "0.9"
+tempfile = "3"

--- a/CPCluster_node/src/lib.rs
+++ b/CPCluster_node/src/lib.rs
@@ -1,0 +1,127 @@
+use cpcluster_common::{Task, TaskResult};
+use meval::shunting_yard::to_rpn;
+use meval::tokenizer::{tokenize, Operation, Token};
+use num_complex::Complex64;
+use once_cell::sync::Lazy;
+use reqwest::Client;
+use std::collections::HashMap;
+use std::path::Path;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpStream, UdpSocket};
+use tokio::sync::Mutex;
+
+static MEMORY: Lazy<Mutex<HashMap<String, Vec<u8>>>> = Lazy::new(|| Mutex::new(HashMap::new()));
+
+fn eval_complex(expr: &str) -> Result<Complex64, String> {
+    let tokens = tokenize(expr).map_err(|e| e.to_string())?;
+    let rpn = to_rpn(&tokens).map_err(|e| format!("{:?}", e))?;
+    let mut stack: Vec<Complex64> = Vec::new();
+    for t in rpn {
+        match t {
+            Token::Number(n) => stack.push(Complex64::new(n, 0.0)),
+            Token::Var(v) => {
+                if v == "i" {
+                    stack.push(Complex64::new(0.0, 1.0));
+                } else {
+                    return Err(format!("unknown var {}", v));
+                }
+            }
+            Token::Binary(op) => {
+                let b = stack.pop().ok_or("stack underflow")?;
+                let a = stack.pop().ok_or("stack underflow")?;
+                let res = match op {
+                    Operation::Plus => a + b,
+                    Operation::Minus => a - b,
+                    Operation::Times => a * b,
+                    Operation::Div => a / b,
+                    Operation::Pow => a.powc(b),
+                    Operation::Rem => Complex64::new(a.re % b.re, a.im),
+                };
+                stack.push(res);
+            }
+            Token::Unary(op) => {
+                let a = stack.pop().ok_or("stack underflow")?;
+                stack.push(match op {
+                    Operation::Plus => a,
+                    Operation::Minus => -a,
+                    _ => return Err("unsupported unary".into()),
+                });
+            }
+            _ => return Err("unsupported token".into()),
+        }
+    }
+    stack.pop().ok_or("no result".into())
+}
+
+pub async fn execute_task(task: Task, client: &Client, storage_dir: &str) -> TaskResult {
+    match task {
+        Task::Compute { expression } => match meval::eval_str(&expression) {
+            Ok(v) => TaskResult::Number(v),
+            Err(e) => TaskResult::Error(e.to_string()),
+        },
+        Task::HttpRequest { url } => match client.get(&url).send().await {
+            Ok(resp) => match resp.text().await {
+                Ok(text) => TaskResult::Response(text),
+                Err(e) => TaskResult::Error(e.to_string()),
+            },
+            Err(e) => TaskResult::Error(e.to_string()),
+        },
+        Task::Tcp { addr, data } => match TcpStream::connect(&addr).await {
+            Ok(mut stream) => {
+                if let Err(e) = stream.write_all(&data).await {
+                    return TaskResult::Error(e.to_string());
+                }
+                let mut buf = vec![0u8; 1024];
+                match stream.read(&mut buf).await {
+                    Ok(n) => TaskResult::Bytes(buf[..n].to_vec()),
+                    Err(e) => TaskResult::Error(e.to_string()),
+                }
+            }
+            Err(e) => TaskResult::Error(e.to_string()),
+        },
+        Task::Udp { addr, data } => match UdpSocket::bind("0.0.0.0:0").await {
+            Ok(socket) => {
+                if let Err(e) = socket.send_to(&data, &addr).await {
+                    return TaskResult::Error(e.to_string());
+                }
+                let mut buf = vec![0u8; 1024];
+                match socket.recv_from(&mut buf).await {
+                    Ok((n, _)) => TaskResult::Bytes(buf[..n].to_vec()),
+                    Err(e) => TaskResult::Error(e.to_string()),
+                }
+            }
+            Err(e) => TaskResult::Error(e.to_string()),
+        },
+        Task::ComplexMath { expression } => match eval_complex(&expression) {
+            Ok(c) => TaskResult::Response(c.to_string()),
+            Err(e) => TaskResult::Error(e),
+        },
+        Task::StoreData { key, data } => {
+            MEMORY.lock().await.insert(key, data);
+            TaskResult::Stored
+        }
+        Task::RetrieveData { key } => match MEMORY.lock().await.get(&key).cloned() {
+            Some(d) => TaskResult::Bytes(d),
+            None => TaskResult::Error("Key not found".into()),
+        },
+        Task::DiskWrite { path, data } => {
+            let full = Path::new(storage_dir).join(&path);
+            if let Some(parent) = full.parent() {
+                if let Err(e) = tokio::fs::create_dir_all(parent).await {
+                    return TaskResult::Error(e.to_string());
+                }
+            }
+            match tokio::fs::write(&full, &data).await {
+                Ok(_) => TaskResult::Written,
+                Err(e) => TaskResult::Error(e.to_string()),
+            }
+        }
+        Task::DiskRead { path } => {
+            let full = Path::new(storage_dir).join(&path);
+            match tokio::fs::read(&full).await {
+                Ok(d) => TaskResult::Bytes(d),
+                Err(e) => TaskResult::Error(e.to_string()),
+            }
+        }
+    }
+}

--- a/CPCluster_node/tests/tasks.rs
+++ b/CPCluster_node/tests/tasks.rs
@@ -1,0 +1,105 @@
+use cpcluster_common::{Task, TaskResult};
+use cpcluster_node::execute_task;
+use reqwest::Client;
+use tempfile::tempdir;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, UdpSocket};
+
+#[tokio::test]
+async fn tcp_and_udp_tasks() {
+    // TCP echo
+    let tcp_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let tcp_addr = tcp_listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let (mut socket, _) = tcp_listener.accept().await.unwrap();
+        let mut buf = [0u8; 5];
+        socket.read_exact(&mut buf).await.unwrap();
+        socket.write_all(b"world").await.unwrap();
+    });
+    let client = Client::new();
+    let res = execute_task(
+        Task::Tcp {
+            addr: tcp_addr.to_string(),
+            data: b"hello".to_vec(),
+        },
+        &client,
+        "./",
+    )
+    .await;
+    assert!(matches!(res, TaskResult::Bytes(ref b) if b == b"world"));
+
+    // UDP echo
+    let udp_socket = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let udp_addr = udp_socket.local_addr().unwrap();
+    tokio::spawn(async move {
+        let mut buf = [0u8; 5];
+        let (n, peer) = udp_socket.recv_from(&mut buf).await.unwrap();
+        assert_eq!(&buf[..n], b"ping");
+        udp_socket.send_to(b"pong", &peer).await.unwrap();
+    });
+    let res = execute_task(
+        Task::Udp {
+            addr: udp_addr.to_string(),
+            data: b"ping".to_vec(),
+        },
+        &client,
+        "./",
+    )
+    .await;
+    assert!(matches!(res, TaskResult::Bytes(ref b) if b == b"pong"));
+}
+
+#[tokio::test]
+async fn complex_and_storage_tasks() {
+    let client = Client::new();
+    // complex math
+    let res = execute_task(
+        Task::ComplexMath {
+            expression: "1+2*i+(3-4*i)".into(),
+        },
+        &client,
+        "./",
+    )
+    .await;
+    assert!(matches!(res, TaskResult::Response(ref s) if s.trim() == "4-2i"));
+
+    // RAM store and retrieve
+    let res = execute_task(
+        Task::StoreData {
+            key: "k".into(),
+            data: b"data".to_vec(),
+        },
+        &client,
+        "./",
+    )
+    .await;
+    assert!(matches!(res, TaskResult::Stored));
+    let res = execute_task(Task::RetrieveData { key: "k".into() }, &client, "./").await;
+    assert!(matches!(res, TaskResult::Bytes(ref b) if b == b"data"));
+}
+
+#[tokio::test]
+async fn disk_tasks() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().to_str().unwrap();
+    let client = Client::new();
+    let res = execute_task(
+        Task::DiskWrite {
+            path: "file.bin".into(),
+            data: b"d".to_vec(),
+        },
+        &client,
+        path,
+    )
+    .await;
+    assert!(matches!(res, TaskResult::Written));
+    let res = execute_task(
+        Task::DiskRead {
+            path: "file.bin".into(),
+        },
+        &client,
+        path,
+    )
+    .await;
+    assert!(matches!(res, TaskResult::Bytes(ref b) if b == b"d"));
+}

--- a/config.json
+++ b/config.json
@@ -7,4 +7,5 @@
   "ca_cert": null,
   "cert_path": null,
   "key_path": null
+  ,"storage_dir": "storage"
 }

--- a/cpcluster_common/src/config.rs
+++ b/cpcluster_common/src/config.rs
@@ -11,6 +11,9 @@ pub struct Config {
     pub ca_cert: Option<String>,
     pub cert_path: Option<String>,
     pub key_path: Option<String>,
+    /// Directory used for on-disk storage by nodes
+    #[serde(default = "default_storage_dir")]
+    pub storage_dir: String,
 }
 
 impl Default for Config {
@@ -24,6 +27,7 @@ impl Default for Config {
             ca_cert: None,
             cert_path: None,
             key_path: None,
+            storage_dir: default_storage_dir(),
         }
     }
 }
@@ -41,4 +45,8 @@ impl Config {
         fs::write(path, data)?;
         Ok(())
     }
+}
+
+fn default_storage_dir() -> String {
+    "storage".to_string()
 }


### PR DESCRIPTION
## Summary
- support TCP/UDP, complex math, RAM and disk storage actions in node
- expose task executor in new library module
- store files under configurable `storage_dir`
- extend configuration for disk storage
- test new behaviours

## Testing
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684c43110b008325829284c6d08f5782