### PR TITLE
Add shared MemoryStore to node

### DIFF
--- a/CPCluster_node/Cargo.toml
+++ b/CPCluster_node/Cargo.toml
@@ -25,7 +25,6 @@ uuid = { version = "1", features = ["v4"] }
 reqwest = { version = "0.11", features = ["rustls-tls"] }
 meval = "0.2"
 num-complex = "0.4"
-once_cell = "1.17"
 cpcluster_common = { path = "../cpcluster_common" }
 rustls-native-certs = "0.8"
 log = "0.4"

--- a/CPCluster_node/README.md
+++ b/CPCluster_node/README.md
@@ -28,3 +28,19 @@ let request = Task::HttpRequest { url: "https://example.com".into() };
 ```
 
 `TaskResult::Number(3.0)` or `TaskResult::Response` will be returned respectively.
+
+## In-memory Storage
+
+The node exposes a simple volatile key/value store implemented in
+`memory_store.rs`. `MemoryStore` is created in `main` and shared with all task
+handlers. Tasks can store and load binary blobs using `Task::StoreData` and
+`Task::RetrieveData` which internally call `MemoryStore::store` and
+`MemoryStore::load`.
+
+```rust
+use cpcluster_node::memory_store::MemoryStore;
+
+let store = MemoryStore::new();
+store.store("example".into(), b"data".to_vec()).await;
+let data = store.load("example").await;
+```

--- a/CPCluster_node/src/main.rs
+++ b/CPCluster_node/src/main.rs
@@ -2,7 +2,7 @@ use cpcluster_common::config::Config;
 use cpcluster_common::{
     is_local_ip, read_length_prefixed, write_length_prefixed, JoinInfo, NodeMessage,
 };
-use cpcluster_node::execute_task;
+use cpcluster_node::{execute_task, memory_store::MemoryStore};
 use log::{error, info, warn};
 use reqwest::Client;
 use rustls_native_certs as native_certs;
@@ -27,6 +27,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let mut stream: Option<Box<dyn ReadWrite + Unpin + Send>> = None;
     let open_tasks: Arc<Mutex<HashMap<String, NodeMessage>>> = Arc::new(Mutex::new(HashMap::new()));
+    let memory = MemoryStore::new();
     for addr in &config.master_addresses {
         match connect(
             addr,
@@ -117,6 +118,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
                             let ca_path = config.ca_cert_path.clone();
                             let ca_cert = config.ca_cert.clone();
                             let storage = config.storage_dir.clone();
+                            let mem = memory.clone();
                             tokio::spawn(async move {
                                 if let Err(e) = handle_connection(
                                     target,
@@ -125,6 +127,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
                                     ca_path.as_deref(),
                                     ca_cert.as_deref(),
                                     &storage,
+                                    mem,
                                 ).await {
                                     error!("Direct connection error: {}", e);
                                 }
@@ -134,7 +137,13 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
                             info!("Received heartbeat acknowledgement from master");
                         }
                         NodeMessage::AssignTask { id, task } => {
-                            let result = execute_task(task, &http_client, &config.storage_dir).await;
+                            let result = execute_task(
+                                task,
+                                &http_client,
+                                &config.storage_dir,
+                                &memory,
+                            )
+                            .await;
                             let msg = NodeMessage::TaskResult {
                                 id: id.clone(),
                                 result,
@@ -297,6 +306,7 @@ async fn handle_connection(
     ca_path: Option<&str>,
     ca_cert: Option<&str>,
     storage_dir: &str,
+    memory: MemoryStore,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
     let addr = format!("{}:{}", target, port);
     let use_tls = !is_local_ip(&target);
@@ -336,7 +346,7 @@ async fn handle_connection(
             Err(_) => break,
         };
         if let Ok(NodeMessage::AssignTask { id, task }) = serde_json::from_slice(&buf) {
-            let result = execute_task(task, &client, storage_dir).await;
+            let result = execute_task(task, &client, storage_dir, &memory).await;
             let msg = NodeMessage::TaskResult {
                 id: id.clone(),
                 result,

--- a/CPCluster_node/src/memory_store.rs
+++ b/CPCluster_node/src/memory_store.rs
@@ -1,0 +1,22 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+#[derive(Clone, Default)]
+pub struct MemoryStore {
+    inner: Arc<Mutex<HashMap<String, Vec<u8>>>>,
+}
+
+impl MemoryStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub async fn store(&self, id: String, data: Vec<u8>) {
+        self.inner.lock().await.insert(id, data);
+    }
+
+    pub async fn load(&self, id: &str) -> Option<Vec<u8>> {
+        self.inner.lock().await.get(id).cloned()
+    }
+}


### PR DESCRIPTION
## Summary
- implement `memory_store` module providing a shared `MemoryStore`
- use `MemoryStore` in `execute_task` and update main to pass it around
- remove once_cell dependency
- update tests for new argument
- document the memory store in the node README

## Testing
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684c47260acc83258568fd3da3837a22