### PR TITLE
Add node roles and disk storage

### DIFF
--- a/CPCluster_masterNode/src/main.rs
+++ b/CPCluster_masterNode/src/main.rs
@@ -1,5 +1,5 @@
 use cpcluster_common::config::Config;
-use cpcluster_common::{is_local_ip, JoinInfo, NodeMessage, Task, TaskResult, NodeRole};
+use cpcluster_common::{is_local_ip, JoinInfo, NodeMessage, NodeRole, Task, TaskResult};
 use cpcluster_common::{read_length_prefixed, write_length_prefixed};
 use log::{error, info, warn};
 use rcgen::generate_simple_self_signed;

--- a/CPCluster_masterNode/src/main.rs
+++ b/CPCluster_masterNode/src/main.rs
@@ -1,5 +1,5 @@
 use cpcluster_common::config::Config;
-use cpcluster_common::{is_local_ip, JoinInfo, NodeMessage, Task, TaskResult};
+use cpcluster_common::{is_local_ip, JoinInfo, NodeMessage, Task, TaskResult, NodeRole};
 use cpcluster_common::{read_length_prefixed, write_length_prefixed};
 use log::{error, info, warn};
 use rcgen::generate_simple_self_signed;
@@ -94,6 +94,8 @@ struct NodeInfo {
     active_tasks: HashMap<String, Task>,
     #[serde(default)]
     is_worker: bool,
+    #[serde(default)]
+    role: NodeRole,
 }
 
 #[derive(Debug, Clone)]
@@ -353,6 +355,7 @@ where
                 port: None,
                 active_tasks: HashMap::new(),
                 is_worker: false,
+                role: NodeRole::Worker,
             },
         );
         save_state(&master_node).await;
@@ -372,6 +375,14 @@ where
 
             let request: NodeMessage = serde_json::from_slice(&data)?;
             match request {
+                NodeMessage::RegisterRole(role) => {
+                    master_node
+                        .connected_nodes
+                        .lock()
+                        .await
+                        .entry(addr.clone())
+                        .and_modify(|n| n.role = role);
+                }
                 NodeMessage::GetConnectedNodes => {
                     // Sende die Liste aller verbundenen Nodes
                     let connected_nodes = master_node

--- a/CPCluster_node/src/disk_store.rs
+++ b/CPCluster_node/src/disk_store.rs
@@ -25,10 +25,7 @@ impl DiskStore {
     }
 
     pub async fn load(&self, id: &str) -> Option<Vec<u8>> {
-        match fs::read(self.dir.join(id)).await {
-            Ok(d) => Some(d),
-            Err(_) => None,
-        }
+        fs::read(self.dir.join(id)).await.ok()
     }
 }
 

--- a/CPCluster_node/src/disk_store.rs
+++ b/CPCluster_node/src/disk_store.rs
@@ -1,0 +1,47 @@
+use std::path::{Path, PathBuf};
+use tokio::fs;
+
+#[derive(Clone)]
+pub struct DiskStore {
+    dir: PathBuf,
+    quota_bytes: u64,
+}
+
+impl DiskStore {
+    pub fn new(dir: PathBuf, quota_mb: u64) -> Self {
+        Self { dir, quota_bytes: quota_mb * 1024 * 1024 }
+    }
+
+    pub async fn store(&self, id: String, data: Vec<u8>) -> std::io::Result<()> {
+        fs::create_dir_all(&self.dir).await?;
+        let usage = directory_size(&self.dir)?;
+        if usage + data.len() as u64 > self.quota_bytes {
+            return Err(std::io::Error::other("quota exceeded"));
+        }
+        fs::write(self.dir.join(id), data).await
+    }
+
+    pub async fn load(&self, id: &str) -> Option<Vec<u8>> {
+        match fs::read(self.dir.join(id)).await {
+            Ok(d) => Some(d),
+            Err(_) => None,
+        }
+    }
+}
+
+fn directory_size(path: &Path) -> std::io::Result<u64> {
+    if !path.exists() {
+        return Ok(0);
+    }
+    let mut size = 0;
+    for entry in std::fs::read_dir(path)? {
+        let entry = entry?;
+        let meta = entry.metadata()?;
+        if meta.is_file() {
+            size += meta.len();
+        } else if meta.is_dir() {
+            size += directory_size(&entry.path())?;
+        }
+    }
+    Ok(size)
+}

--- a/CPCluster_node/src/disk_store.rs
+++ b/CPCluster_node/src/disk_store.rs
@@ -9,7 +9,10 @@ pub struct DiskStore {
 
 impl DiskStore {
     pub fn new(dir: PathBuf, quota_mb: u64) -> Self {
-        Self { dir, quota_bytes: quota_mb * 1024 * 1024 }
+        Self {
+            dir,
+            quota_bytes: quota_mb * 1024 * 1024,
+        }
     }
 
     pub async fn store(&self, id: String, data: Vec<u8>) -> std::io::Result<()> {

--- a/CPCluster_node/src/lib.rs
+++ b/CPCluster_node/src/lib.rs
@@ -3,8 +3,10 @@ use meval::shunting_yard::to_rpn;
 use meval::tokenizer::{tokenize, Operation, Token};
 use num_complex::Complex64;
 pub mod memory_store;
+pub mod disk_store;
 
 use memory_store::MemoryStore;
+use disk_store::DiskStore;
 use reqwest::Client;
 use std::path::Path;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -56,6 +58,7 @@ pub async fn execute_task(
     client: &Client,
     storage_dir: &str,
     store: &MemoryStore,
+    disk: Option<&DiskStore>,
 ) -> TaskResult {
     match task {
         Task::Compute { expression } => match meval::eval_str(&expression) {
@@ -100,13 +103,29 @@ pub async fn execute_task(
             Err(e) => TaskResult::Error(e),
         },
         Task::StoreData { key, data } => {
-            store.store(key, data).await;
-            TaskResult::Stored
+            if let Some(ds) = disk {
+                match ds.store(key, data).await {
+                    Ok(_) => TaskResult::Stored,
+                    Err(e) => TaskResult::Error(e.to_string()),
+                }
+            } else {
+                store.store(key, data).await;
+                TaskResult::Stored
+            }
         }
-        Task::RetrieveData { key } => match store.load(&key).await {
-            Some(d) => TaskResult::Bytes(d),
-            None => TaskResult::Error("Key not found".into()),
-        },
+        Task::RetrieveData { key } => {
+            if let Some(ds) = disk {
+                match ds.load(&key).await {
+                    Some(d) => TaskResult::Bytes(d),
+                    None => TaskResult::Error("Key not found".into()),
+                }
+            } else {
+                match store.load(&key).await {
+                    Some(d) => TaskResult::Bytes(d),
+                    None => TaskResult::Error("Key not found".into()),
+                }
+            }
+        }
         Task::DiskWrite { path, data } => {
             let full = Path::new(storage_dir).join(&path);
             if let Some(parent) = full.parent() {

--- a/CPCluster_node/src/lib.rs
+++ b/CPCluster_node/src/lib.rs
@@ -2,11 +2,11 @@ use cpcluster_common::{Task, TaskResult};
 use meval::shunting_yard::to_rpn;
 use meval::tokenizer::{tokenize, Operation, Token};
 use num_complex::Complex64;
-pub mod memory_store;
 pub mod disk_store;
+pub mod memory_store;
 
-use memory_store::MemoryStore;
 use disk_store::DiskStore;
+use memory_store::MemoryStore;
 use reqwest::Client;
 use std::path::Path;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};

--- a/CPCluster_node/src/main.rs
+++ b/CPCluster_node/src/main.rs
@@ -313,6 +313,7 @@ async fn reconnect(
     )))
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn handle_connection(
     target: String,
     port: u16,

--- a/CPCluster_node/src/main.rs
+++ b/CPCluster_node/src/main.rs
@@ -2,7 +2,7 @@ use cpcluster_common::config::Config;
 use cpcluster_common::{
     is_local_ip, read_length_prefixed, write_length_prefixed, JoinInfo, NodeMessage,
 };
-use cpcluster_node::{execute_task, memory_store::MemoryStore};
+use cpcluster_node::{execute_task, memory_store::MemoryStore, disk_store::DiskStore};
 use log::{error, info, warn};
 use reqwest::Client;
 use rustls_native_certs as native_certs;
@@ -28,6 +28,14 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let mut stream: Option<Box<dyn ReadWrite + Unpin + Send>> = None;
     let open_tasks: Arc<Mutex<HashMap<String, NodeMessage>>> = Arc::new(Mutex::new(HashMap::new()));
     let memory = MemoryStore::new();
+    let disk_store = if config.role == cpcluster_common::NodeRole::Disk {
+        Some(cpcluster_node::disk_store::DiskStore::new(
+            std::path::PathBuf::from(&config.storage_dir),
+            config.disk_space_mb,
+        ))
+    } else {
+        None
+    };
     for addr in &config.master_addresses {
         match connect(
             addr,
@@ -68,6 +76,9 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         return Ok(());
     }
     info!("Authentication successful");
+
+    // inform master about our role
+    send_message(&mut stream, NodeMessage::RegisterRole(config.role.clone())).await?;
 
     // Request to get the list of currently connected nodes
     let get_nodes_request = NodeMessage::GetConnectedNodes;
@@ -119,6 +130,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
                             let ca_cert = config.ca_cert.clone();
                             let storage = config.storage_dir.clone();
                             let mem = memory.clone();
+                            let ds = disk_store.clone();
                             tokio::spawn(async move {
                                 if let Err(e) = handle_connection(
                                     target,
@@ -128,6 +140,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
                                     ca_cert.as_deref(),
                                     &storage,
                                     mem,
+                                    ds,
                                 ).await {
                                     error!("Direct connection error: {}", e);
                                 }
@@ -142,6 +155,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
                                 &http_client,
                                 &config.storage_dir,
                                 &memory,
+                                disk_store.as_ref(),
                             )
                             .await;
                             let msg = NodeMessage::TaskResult {
@@ -307,6 +321,7 @@ async fn handle_connection(
     ca_cert: Option<&str>,
     storage_dir: &str,
     memory: MemoryStore,
+    disk: Option<DiskStore>,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
     let addr = format!("{}:{}", target, port);
     let use_tls = !is_local_ip(&target);
@@ -346,7 +361,14 @@ async fn handle_connection(
             Err(_) => break,
         };
         if let Ok(NodeMessage::AssignTask { id, task }) = serde_json::from_slice(&buf) {
-            let result = execute_task(task, &client, storage_dir, &memory).await;
+            let result = execute_task(
+                task,
+                &client,
+                storage_dir,
+                &memory,
+                disk.as_ref(),
+            )
+            .await;
             let msg = NodeMessage::TaskResult {
                 id: id.clone(),
                 result,

--- a/CPCluster_node/src/main.rs
+++ b/CPCluster_node/src/main.rs
@@ -2,7 +2,7 @@ use cpcluster_common::config::Config;
 use cpcluster_common::{
     is_local_ip, read_length_prefixed, write_length_prefixed, JoinInfo, NodeMessage,
 };
-use cpcluster_node::{execute_task, memory_store::MemoryStore, disk_store::DiskStore};
+use cpcluster_node::{disk_store::DiskStore, execute_task, memory_store::MemoryStore};
 use log::{error, info, warn};
 use reqwest::Client;
 use rustls_native_certs as native_certs;
@@ -361,14 +361,7 @@ async fn handle_connection(
             Err(_) => break,
         };
         if let Ok(NodeMessage::AssignTask { id, task }) = serde_json::from_slice(&buf) {
-            let result = execute_task(
-                task,
-                &client,
-                storage_dir,
-                &memory,
-                disk.as_ref(),
-            )
-            .await;
+            let result = execute_task(task, &client, storage_dir, &memory, disk.as_ref()).await;
             let msg = NodeMessage::TaskResult {
                 id: id.clone(),
                 result,

--- a/CPCluster_node/tests/tasks.rs
+++ b/CPCluster_node/tests/tasks.rs
@@ -26,6 +26,7 @@ async fn tcp_and_udp_tasks() {
         &client,
         "./",
         &store,
+        None,
     )
     .await;
     assert!(matches!(res, TaskResult::Bytes(ref b) if b == b"world"));
@@ -47,6 +48,7 @@ async fn tcp_and_udp_tasks() {
         &client,
         "./",
         &store,
+        None,
     )
     .await;
     assert!(matches!(res, TaskResult::Bytes(ref b) if b == b"pong"));
@@ -64,6 +66,7 @@ async fn complex_and_storage_tasks() {
         &client,
         "./",
         &store,
+        None,
     )
     .await;
     assert!(matches!(res, TaskResult::Response(ref s) if s.trim() == "4-2i"));
@@ -77,6 +80,7 @@ async fn complex_and_storage_tasks() {
         &client,
         "./",
         &store,
+        None,
     )
     .await;
     assert!(matches!(res, TaskResult::Stored));
@@ -85,6 +89,7 @@ async fn complex_and_storage_tasks() {
         &client,
         "./",
         &store,
+        None,
     )
     .await;
     assert!(matches!(res, TaskResult::Bytes(ref b) if b == b"data"));
@@ -104,6 +109,7 @@ async fn disk_tasks() {
         &client,
         path,
         &store,
+        None,
     )
     .await;
     assert!(matches!(res, TaskResult::Written));
@@ -114,6 +120,7 @@ async fn disk_tasks() {
         &client,
         path,
         &store,
+        None,
     )
     .await;
     assert!(matches!(res, TaskResult::Bytes(ref b) if b == b"d"));

--- a/cpcluster_common/src/config.rs
+++ b/cpcluster_common/src/config.rs
@@ -1,6 +1,6 @@
+use crate::NodeRole;
 use serde::{Deserialize, Serialize};
 use std::{error::Error, fs};
-use crate::NodeRole;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Config {

--- a/cpcluster_common/src/config.rs
+++ b/cpcluster_common/src/config.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::{error::Error, fs};
+use crate::NodeRole;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Config {
@@ -14,6 +15,10 @@ pub struct Config {
     /// Directory used for on-disk storage by nodes
     #[serde(default = "default_storage_dir")]
     pub storage_dir: String,
+    #[serde(default = "default_disk_space")]
+    pub disk_space_mb: u64,
+    #[serde(default)]
+    pub role: NodeRole,
 }
 
 impl Default for Config {
@@ -28,6 +33,8 @@ impl Default for Config {
             cert_path: None,
             key_path: None,
             storage_dir: default_storage_dir(),
+            disk_space_mb: default_disk_space(),
+            role: NodeRole::Worker,
         }
     }
 }
@@ -49,4 +56,8 @@ impl Config {
 
 fn default_storage_dir() -> String {
     "storage".to_string()
+}
+
+fn default_disk_space() -> u64 {
+    1024
 }

--- a/cpcluster_common/src/lib.rs
+++ b/cpcluster_common/src/lib.rs
@@ -4,17 +4,12 @@ use std::borrow::Cow;
 pub mod config;
 pub use config::Config;
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
 pub enum NodeRole {
+    #[default]
     Worker,
     Disk,
     Internet,
-}
-
-impl Default for NodeRole {
-    fn default() -> Self {
-        NodeRole::Worker
-    }
 }
 
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};

--- a/cpcluster_common/src/lib.rs
+++ b/cpcluster_common/src/lib.rs
@@ -4,6 +4,19 @@ use std::borrow::Cow;
 pub mod config;
 pub use config::Config;
 
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub enum NodeRole {
+    Worker,
+    Disk,
+    Internet,
+}
+
+impl Default for NodeRole {
+    fn default() -> Self {
+        NodeRole::Worker
+    }
+}
+
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 #[derive(Serialize, Deserialize)]
@@ -51,6 +64,7 @@ pub enum NodeMessage {
     TaskResult { id: String, result: TaskResult },
     TaskAccepted(String),
     DirectMessage(String),
+    RegisterRole(NodeRole),
 }
 
 /// Write a length-prefixed binary message to the provided async writer.


### PR DESCRIPTION
## Summary
- define `NodeRole` enum in `cpcluster_common`
- extend `Config` with role and disk quota fields
- add disk store implementation for disk nodes
- update master to track node roles
- send role on node startup and use disk store when appropriate

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684c4e1b3cd88325ab2480132aec4a4d