### PR TITLE
Add docs and agent guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# Guidelines for Agents
+
+This repository contains multiple Rust crates forming the CPCluster project. The workspace layout is described in `docs/PROJECT_OVERVIEW.md`.
+
+## Conventions
+
+- Format the code using `cargo fmt` before committing.
+- Run `cargo clippy --all-targets` and `cargo test` from the repository root.
+- Commit messages should be in English and briefly describe the change.
+
+## Structure
+
+- `CPCluster_masterNode` – master connection manager.
+- `CPCluster_node` – node implementation.
+- `cpcluster_common` – shared types and helpers.
+- `cpcluster_client` – example client.
+- `docs` – additional documentation.
+
+When adding new files, place further AGENTS.md files in subdirectories if specific instructions are required.
+
+

--- a/CPCluster_masterNode/AGENTS.md
+++ b/CPCluster_masterNode/AGENTS.md
@@ -1,0 +1,8 @@
+# CPCluster Master Node
+
+This directory contains the master node of the cluster. Source code resides in `src` and integration tests in `tests`.
+
+- Run `cargo run` here to start the master for development.
+- Adjust runtime options in `../config.json`.
+- After changes, execute `cargo test` from the repository root.
+

--- a/CPCluster_node/AGENTS.md
+++ b/CPCluster_node/AGENTS.md
@@ -1,0 +1,8 @@
+# CPCluster Node
+
+This crate implements a cluster node. Source files live in `src` and tests in `tests`.
+
+- Start a node with `cargo run` after copying `join.json` from the master directory.
+- Configuration is shared via `../config.json`.
+- Run `cargo test` at the workspace root after modifying the code.
+

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 CPCluster is a distributed network of nodes that communicate with each other for task distribution. The master node in CPCluster serves as a connection manager, coordinating direct connections between nodes without routing their tasks through the master. This approach minimizes latency, improves task performance, and centralizes connection management.
 
+For an overview of the repository structure see docs/PROJECT_OVERVIEW.md.
+
 ## Features
 
 - **Centralized Connection Management**: The master node manages node connections and assigns direct ports for inter-node communication.

--- a/cpcluster_client/AGENTS.md
+++ b/cpcluster_client/AGENTS.md
@@ -1,0 +1,6 @@
+# cpcluster_client
+
+Example client that submits tasks to the master node. Build and run with `cargo run --release`.
+
+Use this crate to experiment with task submission and result handling.
+

--- a/cpcluster_common/AGENTS.md
+++ b/cpcluster_common/AGENTS.md
@@ -1,0 +1,7 @@
+# cpcluster_common
+
+Shared types used across the CPCluster crates. The `Config` helper reads `config.json` and defaults when the file is missing.
+
+- Keep this crate lightweight as it is depended on by all others.
+- Any change here requires `cargo test` from the repository root.
+

--- a/docs/PROJECT_OVERVIEW.md
+++ b/docs/PROJECT_OVERVIEW.md
@@ -1,0 +1,13 @@
+# Project Overview
+
+CPCluster is a collection of Rust crates implementing a simple distributed network. Nodes connect to a master for connection management and exchange tasks directly. The repository is organized as a Cargo workspace containing the following crates:
+
+- **cpcluster_masternode** – master connection manager responsible for authenticating nodes and assigning ports.
+- **cpcluster_node** – client node that connects to the master and communicates with peers.
+- **cpcluster_common** – shared data types like `NodeMessage`, `Task` and `Config`.
+- **cpcluster_client** – example client showing how to submit tasks through the master.
+
+Additional documentation is located in `docs/DEVELOPER_GUIDE.md` and `docs/ROADMAP.md`. A sample configuration lives in `config.json`.
+
+Use `setup_container.sh` to install Rust and build all crates on new systems.
+


### PR DESCRIPTION
## Summary
- add AGENTS.md files describing project structure and per-crate hints
- document repository layout in `docs/PROJECT_OVERVIEW.md`
- link to the new overview from the README

## Testing
- `cargo fmt`
- `cargo clippy --all-targets`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684c4e52b82483258e4f375e0be9241a