### PR TITLE
Update docs for node roles and storage

### DIFF
--- a/CPCluster_node/README.md
+++ b/CPCluster_node/README.md
@@ -44,3 +44,10 @@ let store = MemoryStore::new();
 store.store("example".into(), b"data".to_vec()).await;
 let data = store.load("example").await;
 ```
+
+### Shared-memory storage
+
+When `storage_dir` points to a tmpfs or RAM-disk (for example `/dev/shm/cpcluster`)
+and the node role is `Worker`, tasks can use `DiskWrite` and `DiskRead` as a
+lightweight shared-memory channel between processes. Disk nodes apply the same
+mechanism but persist the files on disk while respecting `disk_space_mb`.

--- a/README.md
+++ b/README.md
@@ -11,9 +11,12 @@ For an overview of the repository structure see docs/PROJECT_OVERVIEW.md.
 - **Direct Node-to-Node Communication**: Nodes establish direct communication channels after being connected, allowing efficient data transfer with minimal latency.
 - **Token-based Authentication**: Nodes authenticate with the master using a unique token stored in a `join.json` file.
  - **Disconnect Handling**: The master node manages disconnections and releases ports when nodes leave the network.
- - **Optional TLS Encryption**: When nodes communicate across the internet, connections to the master node are automatically upgraded to TLS using `tokio-rustls`.
- - **Redundant Masters**: Clients can specify multiple master addresses and automatically fail over if one becomes unavailable.
- - **Heartbeat Monitoring**: Nodes periodically send heartbeats and the master removes entries if a node stops responding.
+- **Optional TLS Encryption**: When nodes communicate across the internet, connections to the master node are automatically upgraded to TLS using `tokio-rustls`.
+- **Redundant Masters**: Clients can specify multiple master addresses and automatically fail over if one becomes unavailable.
+- **Heartbeat Monitoring**: Nodes periodically send heartbeats and the master removes entries if a node stops responding.
+- **Node Roles**: Nodes can run as `Worker` (default), `Disk` or `Internet`. Disk
+  nodes provide persistent storage while Internet nodes are reachable from public
+  networks and always use TLS.
 
 ## Project Structure
 
@@ -98,6 +101,9 @@ For an overview of the repository structure see docs/PROJECT_OVERVIEW.md.
    - Node A and Node B then establish a direct connection on the assigned port.
    - Once connected they can exchange tasks. For example Node A can send `AssignTask` with `Compute { expression: "1+2" }` and Node B replies with `TaskResult::Number(3.0)`.
    - Another example is `HttpRequest { url: "https://example.com" }` which lets a node fetch the page body and return it as `TaskResult::Response`.
+   - Additional task types include `Tcp` and `Udp` for raw socket communication,
+     `ComplexMath` for complex numbers, in-memory `StoreData`/`RetrieveData`, and
+     `DiskWrite`/`DiskRead` for persistent storage.
 4. **Handling Disconnection**:
    - If a node disconnects, the master releases the assigned port for future connections and notifies the other node if necessary.
 
@@ -138,6 +144,27 @@ addtask http https://example.com
 ```
 
 Ensure each node uses the same `join.json` for authentication with the master node.
+
+### Node Configuration Examples
+
+Disk node reserving 2 GB for persistent tasks:
+
+```json
+{
+  "role": "Disk",
+  "storage_dir": "/var/cpcluster",
+  "disk_space_mb": 2048
+}
+```
+
+Worker node using a RAM disk for shared memory between tasks:
+
+```json
+{
+  "role": "Worker",
+  "storage_dir": "/dev/shm/cpcluster"
+}
+```
 
 For additional information on the code layout and contribution hints see
 [`docs/DEVELOPER_GUIDE.md`](docs/DEVELOPER_GUIDE.md).

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -31,6 +31,22 @@ Nodes periodically send heartbeats. If one fails, the failover timeout defined i
 
 - `send_message()` – helper to serialize a `NodeMessage` and send it via `TcpStream`.
 
+### Node roles and configuration
+
+Nodes can operate in different roles defined in `config.json`:
+
+- `Worker` – default mode executing tasks purely in memory.
+- `Disk` – provides persistent storage using `storage_dir` and `disk_space_mb`.
+- `Internet` – reachable from public networks and always uses TLS.
+
+Important configuration fields include:
+
+- `storage_dir` – directory used for disk tasks or shared RAM disks.
+- `disk_space_mb` – quota for disk nodes.
+- `failover_timeout_ms` and `master_addresses` – reconnection behaviour.
+
+`cpcluster_common::Task` includes variants such as `Tcp`, `Udp`, `ComplexMath`, `StoreData`, `RetrieveData`, `DiskWrite` and `DiskRead` in addition to compute and HTTP requests.
+
 ## Contribution hints
 
 1. Make sure [Rust](https://www.rust-lang.org/) is installed. You can run `./setup_container.sh` from the repository root to install all dependencies and build the project.


### PR DESCRIPTION
## Summary
- document node roles in the main README
- list additional task variants and show config examples
- extend developer guide with role and configuration details
- mention shared-memory storage in node README

## Testing
- `cargo fmt`
- `cargo clippy --all-targets`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684c606c1ca483259fad459442b207f9