### PR TITLE
Add RAM and disk stats tasks

### DIFF
--- a/CPCluster_node/src/lib.rs
+++ b/CPCluster_node/src/lib.rs
@@ -145,5 +145,29 @@ pub async fn execute_task(
                 Err(e) => TaskResult::Error(e.to_string()),
             }
         }
+        Task::GetGlobalRam => {
+            let stats = store.stats().await;
+            let mut resp = String::new();
+            for (id, size) in stats {
+                resp.push_str(&format!("{}: {} bytes\n", id, size));
+            }
+            TaskResult::Response(resp)
+        }
+        Task::GetStorage => {
+            if let Some(ds) = disk {
+                match ds.stats().await {
+                    Ok((files, free)) => {
+                        let mut resp = format!("free: {} bytes\n", free);
+                        for (id, size) in files {
+                            resp.push_str(&format!("{}: {} bytes\n", id, size));
+                        }
+                        TaskResult::Response(resp)
+                    }
+                    Err(e) => TaskResult::Error(e.to_string()),
+                }
+            } else {
+                TaskResult::Error("No disk store configured".into())
+            }
+        }
     }
 }

--- a/CPCluster_node/src/memory_store.rs
+++ b/CPCluster_node/src/memory_store.rs
@@ -19,4 +19,10 @@ impl MemoryStore {
     pub async fn load(&self, id: &str) -> Option<Vec<u8>> {
         self.inner.lock().await.get(id).cloned()
     }
+
+    /// Return a list of all stored keys with their size in bytes
+    pub async fn stats(&self) -> Vec<(String, usize)> {
+        let map = self.inner.lock().await;
+        map.iter().map(|(k, v)| (k.clone(), v.len())).collect()
+    }
 }

--- a/cpcluster_common/src/lib.rs
+++ b/cpcluster_common/src/lib.rs
@@ -23,15 +23,41 @@ pub struct JoinInfo {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum Task {
-    Compute { expression: Cow<'static, str> },
-    HttpRequest { url: String },
-    Tcp { addr: String, data: Vec<u8> },
-    Udp { addr: String, data: Vec<u8> },
-    ComplexMath { expression: Cow<'static, str> },
-    StoreData { key: String, data: Vec<u8> },
-    RetrieveData { key: String },
-    DiskWrite { path: String, data: Vec<u8> },
-    DiskRead { path: String },
+    Compute {
+        expression: Cow<'static, str>,
+    },
+    HttpRequest {
+        url: String,
+    },
+    Tcp {
+        addr: String,
+        data: Vec<u8>,
+    },
+    Udp {
+        addr: String,
+        data: Vec<u8>,
+    },
+    ComplexMath {
+        expression: Cow<'static, str>,
+    },
+    StoreData {
+        key: String,
+        data: Vec<u8>,
+    },
+    RetrieveData {
+        key: String,
+    },
+    DiskWrite {
+        path: String,
+        data: Vec<u8>,
+    },
+    DiskRead {
+        path: String,
+    },
+    /// Return a list of all in-memory IDs with their size in bytes
+    GetGlobalRam,
+    /// Return disk usage statistics and file sizes for stored data
+    GetStorage,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]


### PR DESCRIPTION
## Summary
- add `GetGlobalRam` and `GetStorage` task variants
- implement stats helper on memory and disk stores
- handle new tasks in node execution logic

## Testing
- `cargo fmt`
- `cargo clippy --all-targets`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684c63de384483258b228c9d93e6d831