### PR TITLE
Add Internet node ports

### DIFF
--- a/CPCluster_node/src/internet_ports.rs
+++ b/CPCluster_node/src/internet_ports.rs
@@ -1,0 +1,60 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use tokio::net::{TcpListener, UdpSocket};
+
+pub struct InternetPorts {
+    tcp: Vec<Arc<TcpListener>>,
+    udp: Vec<Arc<UdpSocket>>,
+    tcp_idx: AtomicUsize,
+    udp_idx: AtomicUsize,
+}
+
+impl Clone for InternetPorts {
+    fn clone(&self) -> Self {
+        Self {
+            tcp: self.tcp.clone(),
+            udp: self.udp.clone(),
+            tcp_idx: AtomicUsize::new(self.tcp_idx.load(Ordering::Relaxed)),
+            udp_idx: AtomicUsize::new(self.udp_idx.load(Ordering::Relaxed)),
+        }
+    }
+}
+
+impl InternetPorts {
+    pub async fn bind(ports: &[u16]) -> Self {
+        let mut tcp = Vec::new();
+        let mut udp = Vec::new();
+        for p in ports {
+            if let Ok(listener) = TcpListener::bind(("0.0.0.0", *p)).await {
+                tcp.push(Arc::new(listener));
+            }
+            if let Ok(sock) = UdpSocket::bind(("0.0.0.0", *p)).await {
+                udp.push(Arc::new(sock));
+            }
+        }
+        Self {
+            tcp,
+            udp,
+            tcp_idx: AtomicUsize::new(0),
+            udp_idx: AtomicUsize::new(0),
+        }
+    }
+
+    pub fn tcp_port(&self) -> Option<u16> {
+        if self.tcp.is_empty() {
+            None
+        } else {
+            let idx = self.tcp_idx.fetch_add(1, Ordering::Relaxed) % self.tcp.len();
+            self.tcp[idx].local_addr().ok().map(|a| a.port())
+        }
+    }
+
+    pub fn udp_socket(&self) -> Option<Arc<UdpSocket>> {
+        if self.udp.is_empty() {
+            None
+        } else {
+            let idx = self.udp_idx.fetch_add(1, Ordering::Relaxed) % self.udp.len();
+            Some(self.udp[idx].clone())
+        }
+    }
+}

--- a/CPCluster_node/src/main.rs
+++ b/CPCluster_node/src/main.rs
@@ -2,7 +2,9 @@ use cpcluster_common::config::Config;
 use cpcluster_common::{
     is_local_ip, read_length_prefixed, write_length_prefixed, JoinInfo, NodeMessage,
 };
-use cpcluster_node::{disk_store::DiskStore, execute_task, memory_store::MemoryStore};
+use cpcluster_node::{
+    disk_store::DiskStore, execute_task, internet_ports::InternetPorts, memory_store::MemoryStore,
+};
 use log::{error, info, warn};
 use reqwest::Client;
 use rustls_native_certs as native_certs;
@@ -33,6 +35,19 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
             std::path::PathBuf::from(&config.storage_dir),
             config.disk_space_mb,
         ))
+    } else {
+        None
+    };
+    let internet_ports = if config.role == cpcluster_common::NodeRole::Internet {
+        if let Some(ports) = &config.internet_ports {
+            Some(Arc::new(
+                cpcluster_node::internet_ports::InternetPorts::bind(ports).await,
+            ))
+        } else {
+            Some(Arc::new(
+                cpcluster_node::internet_ports::InternetPorts::bind(&[]).await,
+            ))
+        }
     } else {
         None
     };
@@ -131,6 +146,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
                             let storage = config.storage_dir.clone();
                             let mem = memory.clone();
                             let ds = disk_store.clone();
+                            let internet = internet_ports.clone();
                             tokio::spawn(async move {
                                 if let Err(e) = handle_connection(
                                     target,
@@ -141,6 +157,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
                                     &storage,
                                     mem,
                                     ds,
+                                    internet.as_deref(),
                                 ).await {
                                     error!("Direct connection error: {}", e);
                                 }
@@ -156,6 +173,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
                                 &config.storage_dir,
                                 &memory,
                                 disk_store.as_ref(),
+                                internet_ports.as_deref(),
                             )
                             .await;
                             let msg = NodeMessage::TaskResult {
@@ -323,6 +341,7 @@ async fn handle_connection(
     storage_dir: &str,
     memory: MemoryStore,
     disk: Option<DiskStore>,
+    internet_ports: Option<&InternetPorts>,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
     let addr = format!("{}:{}", target, port);
     let use_tls = !is_local_ip(&target);
@@ -362,7 +381,15 @@ async fn handle_connection(
             Err(_) => break,
         };
         if let Ok(NodeMessage::AssignTask { id, task }) = serde_json::from_slice(&buf) {
-            let result = execute_task(task, &client, storage_dir, &memory, disk.as_ref()).await;
+            let result = execute_task(
+                task,
+                &client,
+                storage_dir,
+                &memory,
+                disk.as_ref(),
+                internet_ports.as_deref(),
+            )
+            .await;
             let msg = NodeMessage::TaskResult {
                 id: id.clone(),
                 result,

--- a/CPCluster_node/src/main.rs
+++ b/CPCluster_node/src/main.rs
@@ -387,7 +387,7 @@ async fn handle_connection(
                 storage_dir,
                 &memory,
                 disk.as_ref(),
-                internet_ports.as_deref(),
+                internet_ports,
             )
             .await;
             let msg = NodeMessage::TaskResult {

--- a/CPCluster_node/tests/tasks.rs
+++ b/CPCluster_node/tests/tasks.rs
@@ -27,6 +27,7 @@ async fn tcp_and_udp_tasks() {
         "./",
         &store,
         None,
+        None,
     )
     .await;
     assert!(matches!(res, TaskResult::Bytes(ref b) if b == b"world"));
@@ -49,6 +50,7 @@ async fn tcp_and_udp_tasks() {
         "./",
         &store,
         None,
+        None,
     )
     .await;
     assert!(matches!(res, TaskResult::Bytes(ref b) if b == b"pong"));
@@ -67,6 +69,7 @@ async fn complex_and_storage_tasks() {
         "./",
         &store,
         None,
+        None,
     )
     .await;
     assert!(matches!(res, TaskResult::Response(ref s) if s.trim() == "4-2i"));
@@ -81,6 +84,7 @@ async fn complex_and_storage_tasks() {
         "./",
         &store,
         None,
+        None,
     )
     .await;
     assert!(matches!(res, TaskResult::Stored));
@@ -89,6 +93,7 @@ async fn complex_and_storage_tasks() {
         &client,
         "./",
         &store,
+        None,
         None,
     )
     .await;
@@ -110,6 +115,7 @@ async fn disk_tasks() {
         path,
         &store,
         None,
+        None,
     )
     .await;
     assert!(matches!(res, TaskResult::Written));
@@ -120,6 +126,7 @@ async fn disk_tasks() {
         &client,
         path,
         &store,
+        None,
         None,
     )
     .await;

--- a/README.md
+++ b/README.md
@@ -166,6 +166,15 @@ Worker node using a RAM disk for shared memory between tasks:
 }
 ```
 
+Internet node opening specific ports for network tasks:
+
+```json
+{
+  "role": "Internet",
+  "internet_ports": [8080, 8443]
+}
+```
+
 For additional information on the code layout and contribution hints see
 [`docs/DEVELOPER_GUIDE.md`](docs/DEVELOPER_GUIDE.md).
 

--- a/cpcluster_common/src/config.rs
+++ b/cpcluster_common/src/config.rs
@@ -12,6 +12,8 @@ pub struct Config {
     pub ca_cert: Option<String>,
     pub cert_path: Option<String>,
     pub key_path: Option<String>,
+    /// Ports bound by Internet nodes for outgoing network requests
+    pub internet_ports: Option<Vec<u16>>,
     /// Directory used for on-disk storage by nodes
     #[serde(default = "default_storage_dir")]
     pub storage_dir: String,
@@ -32,6 +34,7 @@ impl Default for Config {
             ca_cert: None,
             cert_path: None,
             key_path: None,
+            internet_ports: None,
             storage_dir: default_storage_dir(),
             disk_space_mb: default_disk_space(),
             role: NodeRole::Worker,

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -44,6 +44,7 @@ Important configuration fields include:
 - `storage_dir` – directory used for disk tasks or shared RAM disks.
 - `disk_space_mb` – quota for disk nodes.
 - `failover_timeout_ms` and `master_addresses` – reconnection behaviour.
+- `internet_ports` – list of ports bound by Internet nodes.
 
 `cpcluster_common::Task` includes variants such as `Tcp`, `Udp`, `ComplexMath`, `StoreData`, `RetrieveData`, `DiskWrite` and `DiskRead` in addition to compute and HTTP requests.
 


### PR DESCRIPTION
## Summary
- extend configuration with `internet_ports` for Internet nodes
- add `InternetPorts` helper to manage bound ports
- update node logic to bind ports and use them for TCP/UDP tasks
- document configuration in README and developer guide

## Testing
- `cargo fmt`
- `cargo clippy --all-targets`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684c6ccb71e08325ba89b425732ca106