### PR TITLE
Add client integration tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,3 +46,24 @@ jobs:
     - name: Run tests for ${{ matrix.project }}
       working-directory: ${{ matrix.project }}
       run: cargo test --verbose
+
+  workspace_tests:
+    runs-on: ubuntu-latest
+    needs: build_and_test
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+
+      - name: Check formatting
+        run: cargo fmt -- --check
+
+      - name: Run clippy
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Run workspace tests
+        run: cargo test --all --verbose

--- a/cpcluster_client/src/lib.rs
+++ b/cpcluster_client/src/lib.rs
@@ -1,0 +1,51 @@
+use cpcluster_common::{
+    NodeMessage, Task, TaskResult, read_length_prefixed, write_length_prefixed,
+};
+use meval::eval_str;
+use reqwest::Client;
+use std::error::Error;
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::time::{Duration, sleep};
+use uuid::Uuid;
+
+pub async fn submit_and_wait<S>(
+    stream: &mut S,
+    task: Task,
+) -> Result<TaskResult, Box<dyn Error + Send + Sync>>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let id = Uuid::new_v4().to_string();
+    let msg = NodeMessage::SubmitTask {
+        id: id.clone(),
+        task,
+    };
+    write_length_prefixed(stream, &serde_json::to_vec(&msg)?).await?;
+    let _ = read_length_prefixed(stream).await?; // TaskAccepted
+    loop {
+        let req = NodeMessage::GetTaskResult(id.clone());
+        write_length_prefixed(stream, &serde_json::to_vec(&req)?).await?;
+        let buf = read_length_prefixed(stream).await?;
+        match serde_json::from_slice::<NodeMessage>(&buf)? {
+            NodeMessage::TaskResult { result, .. } => return Ok(result),
+            _ => sleep(Duration::from_millis(500)).await,
+        }
+    }
+}
+
+pub async fn execute_task(task: Task, client: &Client) -> TaskResult {
+    match task {
+        Task::Compute { expression } => match eval_str(&expression) {
+            Ok(v) => TaskResult::Number(v),
+            Err(e) => TaskResult::Error(e.to_string()),
+        },
+        Task::HttpRequest { url } => match client.get(&url).send().await {
+            Ok(resp) => match resp.text().await {
+                Ok(text) => TaskResult::Response(text),
+                Err(e) => TaskResult::Error(e.to_string()),
+            },
+            Err(e) => TaskResult::Error(e.to_string()),
+        },
+        _ => TaskResult::Error("Unsupported task".into()),
+    }
+}

--- a/cpcluster_client/tests/integration.rs
+++ b/cpcluster_client/tests/integration.rs
@@ -1,0 +1,59 @@
+use cpcluster_client::{execute_task, submit_and_wait};
+use cpcluster_common::{
+    NodeMessage, Task, TaskResult, read_length_prefixed, write_length_prefixed,
+};
+use reqwest::Client;
+use std::borrow::Cow;
+use tokio::io::duplex;
+
+#[tokio::test]
+async fn submit_and_wait_returns_result() {
+    let (mut client_stream, mut server_stream) = duplex(1024);
+
+    let server = tokio::spawn(async move {
+        // read submit message
+        let buf = read_length_prefixed(&mut server_stream).await.unwrap();
+        let msg: NodeMessage = serde_json::from_slice(&buf).unwrap();
+        if let NodeMessage::SubmitTask { id, .. } = msg {
+            let ack = NodeMessage::TaskAccepted(id.clone());
+            write_length_prefixed(&mut server_stream, &serde_json::to_vec(&ack).unwrap())
+                .await
+                .unwrap();
+            let buf = read_length_prefixed(&mut server_stream).await.unwrap();
+            let req: NodeMessage = serde_json::from_slice(&buf).unwrap();
+            if matches!(req, NodeMessage::GetTaskResult(_)) {
+                let result = NodeMessage::TaskResult {
+                    id,
+                    result: TaskResult::Number(5.0),
+                };
+                write_length_prefixed(&mut server_stream, &serde_json::to_vec(&result).unwrap())
+                    .await
+                    .unwrap();
+            }
+        }
+    });
+
+    let task = Task::Compute {
+        expression: Cow::Borrowed("2+3"),
+    };
+
+    let res = submit_and_wait(&mut client_stream, task).await.unwrap();
+    server.await.unwrap();
+    match res {
+        TaskResult::Number(v) => assert!((v - 5.0).abs() < f64::EPSILON),
+        other => panic!("unexpected result: {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn execute_task_compute() {
+    let http_client = Client::new();
+    let task = Task::Compute {
+        expression: Cow::Borrowed("6/2"),
+    };
+    let result = execute_task(task, &http_client).await;
+    match result {
+        TaskResult::Number(v) => assert!((v - 3.0).abs() < f64::EPSILON),
+        other => panic!("unexpected result: {:?}", other),
+    }
+}


### PR DESCRIPTION
## Summary
- test `submit_and_wait` and `execute_task` in cpcluster_client
- expose client helpers via new library module
- add workspace test job to CI

## Testing
- `cargo clippy --all-targets -q`
- `cargo test --quiet --all | tail -n 20`
- `cargo test --all --quiet --test integration -- --nocapture | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_684c914a8174832588d58bc2ae97cea1