### PR TITLE
Improve setup script and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ For an overview of the repository structure see docs/PROJECT_OVERVIEW.md.
 
 ## Getting Started
 
+### Supported Environments
+
+The project is primarily developed on Linux and macOS. The provided
+`setup_container.sh` script detects common package managers (`apt`, `dnf`, `yum`,
+`pacman` and `brew`) to install prerequisites automatically. On other platforms
+or when detection fails, install `curl`, `git`, a C toolchain, `pkg-config` and
+OpenSSL development libraries manually before building.
+
 ### Prerequisites
 
 - [Rust](https://www.rust-lang.org/) programming language
@@ -38,10 +46,10 @@ For an overview of the repository structure see docs/PROJECT_OVERVIEW.md.
    ```
 
    You can run `./setup_container.sh` from the repository root to install Rust
-   and all required packages automatically. The script detects a supported
-   package manager (e.g. `apt`, `dnf`, `yum`), installs dependencies and builds
-   both crates. If no known package manager is found you will need to install
-   `curl`, `git`, `build-essential`, `pkg-config` and `libssl-dev` manually
+   and all required packages automatically. The script detects common package
+   managers (`apt`, `dnf`, `yum`, `pacman`, `brew`), installs dependencies and
+   builds the crates. If your system uses a different manager, install `curl`,
+   `git`, a C toolchain, `pkg-config` and OpenSSL development libraries manually
    before running the script.
 
 2. **Navigate to each project**:

--- a/setup_container.sh
+++ b/setup_container.sh
@@ -13,18 +13,35 @@ elif command -v dnf >/dev/null 2>&1; then
 elif command -v yum >/dev/null 2>&1; then
     pkg_cmd="yum"
     install_cmd="install -y"
+elif command -v pacman >/dev/null 2>&1; then
+    pkg_cmd="pacman"
+    install_cmd="-Syu --noconfirm"
+elif command -v brew >/dev/null 2>&1; then
+    pkg_cmd="brew"
+    install_cmd="install"
 else
-    echo "No supported package manager found. Please install curl, git, build-essential, pkg-config and libssl-dev manually." >&2
+    echo "No supported package manager found. Please install curl, git, pkg-config, openssl development libraries and build tools manually." >&2
     pkg_cmd=""
 fi
 
 if [ -n "$pkg_cmd" ]; then
-    if [ "$(id -u)" -ne 0 ]; then
-        sudo $pkg_cmd update
-        sudo $pkg_cmd $install_cmd curl git build-essential pkg-config libssl-dev
+    if [ "$pkg_cmd" = "pacman" ]; then
+        update_cmd="-Sy"
+        deps="base-devel git curl pkgconf openssl"
+    elif [ "$pkg_cmd" = "brew" ]; then
+        update_cmd="update"
+        deps="git curl pkg-config openssl@3"
     else
-        $pkg_cmd update
-        $pkg_cmd $install_cmd curl git build-essential pkg-config libssl-dev
+        update_cmd="update"
+        deps="curl git build-essential pkg-config libssl-dev"
+    fi
+
+    if [ "$(id -u)" -ne 0 ] && [ "$pkg_cmd" != "brew" ]; then
+        sudo $pkg_cmd $update_cmd
+        sudo $pkg_cmd $install_cmd $deps
+    else
+        $pkg_cmd $update_cmd
+        $pkg_cmd $install_cmd $deps
     fi
 fi
 


### PR DESCRIPTION
## Summary
- detect `pacman` and `brew` in `setup_container.sh`
- clarify supported environments in `README`
- list new package managers in installation instructions

## Testing
- `cargo fmt`
- `cargo clippy --all-targets`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684c970c3f0c83258805080f45a0199b