### PR TITLE
Add reconnect backoff with configurable retries

### DIFF
--- a/CPCluster_node/tests/reconnect.rs
+++ b/CPCluster_node/tests/reconnect.rs
@@ -1,0 +1,41 @@
+use cpcluster_common::{
+    read_length_prefixed, write_length_prefixed, Config, JoinInfo, NodeMessage,
+};
+use cpcluster_node::node::connect_to_master;
+use std::time::Duration;
+use tokio::net::TcpListener;
+
+#[tokio::test]
+async fn connect_with_backoff() {
+    // pick unused port then release
+    let tmp = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = tmp.local_addr().unwrap().port();
+    drop(tmp);
+    let addr = format!("127.0.0.1:{}", port);
+    let join = JoinInfo {
+        token: "tok".into(),
+        ip: "127.0.0.1".into(),
+        port,
+    };
+    let mut config = Config::default();
+    config.master_addresses = vec![addr.clone()];
+    config.max_retries = 5;
+
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        let listener = TcpListener::bind(addr).await.unwrap();
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let token_bytes = read_length_prefixed(&mut socket).await.unwrap();
+        assert_eq!(std::str::from_utf8(&token_bytes).unwrap(), "tok");
+        write_length_prefixed(&mut socket, b"OK").await.unwrap();
+        let _ = read_length_prefixed(&mut socket).await.unwrap(); // RegisterRole
+        let _ = read_length_prefixed(&mut socket).await.unwrap(); // GetConnectedNodes
+        let resp = NodeMessage::ConnectedNodes(Vec::new());
+        write_length_prefixed(&mut socket, &serde_json::to_vec(&resp).unwrap())
+            .await
+            .unwrap();
+    });
+
+    let res = connect_to_master(&join, &config).await;
+    assert!(res.is_ok());
+}

--- a/config.json
+++ b/config.json
@@ -6,6 +6,7 @@
   "ca_cert_path": null,
   "ca_cert": null,
   "cert_path": null,
-  "key_path": null
-  ,"storage_dir": "storage"
+  "key_path": null,
+  "storage_dir": "storage",
+  "max_retries": 5
 }

--- a/cpcluster_common/src/config.rs
+++ b/cpcluster_common/src/config.rs
@@ -21,6 +21,8 @@ pub struct Config {
     pub disk_space_mb: u64,
     #[serde(default)]
     pub role: NodeRole,
+    #[serde(default = "default_max_retries")]
+    pub max_retries: u32,
 }
 
 impl Default for Config {
@@ -38,6 +40,7 @@ impl Default for Config {
             storage_dir: default_storage_dir(),
             disk_space_mb: default_disk_space(),
             role: NodeRole::Worker,
+            max_retries: default_max_retries(),
         }
     }
 }
@@ -63,4 +66,8 @@ fn default_storage_dir() -> String {
 
 fn default_disk_space() -> u64 {
     1024
+}
+
+fn default_max_retries() -> u32 {
+    5
 }

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -45,6 +45,7 @@ Important configuration fields include:
 - `disk_space_mb` – quota for disk nodes.
 - `role` – choose `Worker`, `Disk` or `Internet`.
 - `failover_timeout_ms` and `master_addresses` – reconnection behaviour.
+- `max_retries` – limit for connection attempts when (re)joining the master.
 - `internet_ports` – list of ports bound by Internet nodes.
 
 `cpcluster_common::Task` includes variants such as `Tcp`, `Udp`, `ComplexMath`, `StoreData`, `RetrieveData`, `DiskWrite`, `DiskRead`, `GetGlobalRam` and `GetStorage` in addition to compute and HTTP requests.


### PR DESCRIPTION
## Summary
- implement retry count in `Config`
- add exponential backoff in node connection logic
- document new `max_retries` setting
- test reconnection behaviour with delayed master

## Testing
- `cargo clippy --all-targets`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684d0c112fdc83259ff7ab91bd7992aa