### PR TITLE
Improve test error handling

### DIFF
--- a/CPCluster_masterNode/tests/integration.rs
+++ b/CPCluster_masterNode/tests/integration.rs
@@ -6,10 +6,10 @@ use std::{
 use tokio::net::TcpListener;
 
 #[tokio::test]
-async fn master_node_interaction() {
+async fn master_node_interaction() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // choose random port for master
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
     let token = "testtoken".to_string();
     let token_srv = token.clone();
 
@@ -19,63 +19,75 @@ async fn master_node_interaction() {
 
     // spawn simplified master server
     let server = tokio::spawn(async move {
-        let (mut socket, _) = listener.accept().await.unwrap();
-        let token_bytes = read_length_prefixed(&mut socket).await.unwrap();
-        assert_eq!(std::str::from_utf8(&token_bytes).unwrap(), token_srv);
-        write_length_prefixed(&mut socket, b"OK").await.unwrap();
+        let (mut socket, _) = listener.accept().await.expect("accept connection");
+        let token_bytes = read_length_prefixed(&mut socket).await.expect("read token");
+        assert_eq!(
+            std::str::from_utf8(&token_bytes).expect("valid UTF-8"),
+            token_srv
+        );
+        write_length_prefixed(&mut socket, b"OK")
+            .await
+            .expect("send auth response");
 
-        let msg = read_length_prefixed(&mut socket).await.unwrap();
-        let msg: NodeMessage = serde_json::from_slice(&msg).unwrap();
+        let msg = read_length_prefixed(&mut socket)
+            .await
+            .expect("read message");
+        let msg: NodeMessage = serde_json::from_slice(&msg).expect("deserialize message");
         assert!(matches!(msg, NodeMessage::GetConnectedNodes));
         let resp = NodeMessage::ConnectedNodes(vec!["node1".into()]);
-        write_length_prefixed(&mut socket, &serde_json::to_vec(&resp).unwrap())
-            .await
-            .unwrap();
+        write_length_prefixed(
+            &mut socket,
+            &serde_json::to_vec(&resp).expect("serialize response"),
+        )
+        .await
+        .expect("send connected nodes");
 
-        let msg = read_length_prefixed(&mut socket).await.unwrap();
-        let msg: NodeMessage = serde_json::from_slice(&msg).unwrap();
+        let msg = read_length_prefixed(&mut socket)
+            .await
+            .expect("read connection request");
+        let msg: NodeMessage =
+            serde_json::from_slice(&msg).expect("deserialize connection request");
         if let NodeMessage::RequestConnection(id) = msg {
             let port = {
-                let mut set = ports_srv.lock().unwrap();
-                let p = *set.iter().next().unwrap();
+                let mut set = ports_srv.lock().expect("lock ports");
+                let p = *set.iter().next().expect("port available");
                 set.remove(&p);
                 p
             };
             let resp = NodeMessage::ConnectionInfo(id, port);
-            write_length_prefixed(&mut socket, &serde_json::to_vec(&resp).unwrap())
-                .await
-                .unwrap();
+            write_length_prefixed(
+                &mut socket,
+                &serde_json::to_vec(&resp).expect("serialize connection info"),
+            )
+            .await
+            .expect("send connection info");
         } else {
             panic!("unexpected message: {:?}", msg);
         }
     });
 
     // spawn client node
-    let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
-    write_length_prefixed(&mut stream, token.as_bytes())
-        .await
-        .unwrap();
-    let resp = read_length_prefixed(&mut stream).await.unwrap();
+    let mut stream = tokio::net::TcpStream::connect(addr).await?;
+    write_length_prefixed(&mut stream, token.as_bytes()).await?;
+    let resp = read_length_prefixed(&mut stream).await?;
     assert_eq!(&resp[..], b"OK");
 
     write_length_prefixed(
         &mut stream,
-        &serde_json::to_vec(&NodeMessage::GetConnectedNodes).unwrap(),
+        &serde_json::to_vec(&NodeMessage::GetConnectedNodes)?,
     )
-    .await
-    .unwrap();
-    let msg = read_length_prefixed(&mut stream).await.unwrap();
-    let msg: NodeMessage = serde_json::from_slice(&msg).unwrap();
+    .await?;
+    let msg = read_length_prefixed(&mut stream).await?;
+    let msg: NodeMessage = serde_json::from_slice(&msg)?;
     assert!(matches!(msg, NodeMessage::ConnectedNodes(_)));
 
     write_length_prefixed(
         &mut stream,
-        &serde_json::to_vec(&NodeMessage::RequestConnection("node1".into())).unwrap(),
+        &serde_json::to_vec(&NodeMessage::RequestConnection("node1".into()))?,
     )
-    .await
-    .unwrap();
-    let msg = read_length_prefixed(&mut stream).await.unwrap();
-    let msg: NodeMessage = serde_json::from_slice(&msg).unwrap();
+    .await?;
+    let msg = read_length_prefixed(&mut stream).await?;
+    let msg: NodeMessage = serde_json::from_slice(&msg)?;
     let allocated_port = match msg {
         NodeMessage::ConnectionInfo(target, port) => {
             assert_eq!(target, "node1");
@@ -85,9 +97,10 @@ async fn master_node_interaction() {
     };
 
     // ensure port allocation removed it from available set
-    assert!(ports.lock().unwrap().is_empty());
+    assert!(ports.lock().expect("lock ports").is_empty());
     assert_eq!(allocated_port, addr.port() + 1);
 
     // ensure server task completes
-    server.await.unwrap();
+    server.await.expect("server task failed");
+    Ok(())
 }

--- a/CPCluster_masterNode/tests/tls.rs
+++ b/CPCluster_masterNode/tests/tls.rs
@@ -6,10 +6,10 @@ use tokio::net::TcpListener;
 use tokio_rustls::{rustls, TlsAcceptor, TlsConnector};
 
 #[tokio::test]
-async fn tls_handshake() {
+async fn tls_handshake() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // generate certificate
-    let cert = generate_simple_self_signed(vec!["localhost".into()]).unwrap();
-    let cert_der = cert.serialize_der().unwrap();
+    let cert = generate_simple_self_signed(vec!["localhost".into()])?;
+    let cert_der = cert.serialize_der()?;
     let key_der = cert.serialize_private_key_der();
     let tls_config = rustls::ServerConfig::builder()
         .with_safe_defaults()
@@ -18,12 +18,12 @@ async fn tls_handshake() {
             vec![rustls::Certificate(cert_der.clone())],
             rustls::PrivateKey(key_der),
         )
-        .unwrap();
+        .expect("create TLS config");
     let acceptor = TlsAcceptor::from(Arc::new(tls_config));
 
     // random port
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
     let token = "testtoken".to_string();
     let token_srv = token.clone();
     let ports = Arc::new(Mutex::new(HashSet::from([addr.port() + 1])));
@@ -31,75 +31,90 @@ async fn tls_handshake() {
 
     // master server
     let server = tokio::spawn(async move {
-        let (socket, _) = listener.accept().await.unwrap();
-        let mut socket = acceptor.accept(socket).await.unwrap();
-        let token_bytes = read_length_prefixed(&mut socket).await.unwrap();
-        assert_eq!(std::str::from_utf8(&token_bytes).unwrap(), token_srv);
-        write_length_prefixed(&mut socket, b"OK").await.unwrap();
+        let (socket, _) = listener.accept().await.expect("accept connection");
+        let mut socket = acceptor.accept(socket).await.expect("TLS accept");
+        let token_bytes = read_length_prefixed(&mut socket).await.expect("read token");
+        assert_eq!(
+            std::str::from_utf8(&token_bytes).expect("valid UTF-8"),
+            token_srv
+        );
+        write_length_prefixed(&mut socket, b"OK")
+            .await
+            .expect("send auth response");
 
-        let msg = read_length_prefixed(&mut socket).await.unwrap();
-        let msg: NodeMessage = serde_json::from_slice(&msg).unwrap();
+        let msg = read_length_prefixed(&mut socket)
+            .await
+            .expect("read message");
+        let msg: NodeMessage = serde_json::from_slice(&msg).expect("deserialize message");
         assert!(matches!(msg, NodeMessage::GetConnectedNodes));
         let resp = NodeMessage::ConnectedNodes(vec!["node1".into()]);
-        write_length_prefixed(&mut socket, &serde_json::to_vec(&resp).unwrap())
-            .await
-            .unwrap();
+        write_length_prefixed(
+            &mut socket,
+            &serde_json::to_vec(&resp).expect("serialize response"),
+        )
+        .await
+        .expect("send connected nodes");
 
-        let msg = read_length_prefixed(&mut socket).await.unwrap();
-        let msg: NodeMessage = serde_json::from_slice(&msg).unwrap();
+        let msg = read_length_prefixed(&mut socket)
+            .await
+            .expect("read connection request");
+        let msg: NodeMessage =
+            serde_json::from_slice(&msg).expect("deserialize connection request");
         if let NodeMessage::RequestConnection(id) = msg {
             let port = {
-                let mut set = ports_srv.lock().unwrap();
-                let p = *set.iter().next().unwrap();
+                let mut set = ports_srv.lock().expect("lock ports");
+                let p = *set.iter().next().expect("port available");
                 set.remove(&p);
                 p
             };
             let resp = NodeMessage::ConnectionInfo(id, port);
-            write_length_prefixed(&mut socket, &serde_json::to_vec(&resp).unwrap())
-                .await
-                .unwrap();
+            write_length_prefixed(
+                &mut socket,
+                &serde_json::to_vec(&resp).expect("serialize connection info"),
+            )
+            .await
+            .expect("send connection info");
         }
     });
 
     // client setup
     let mut root_store = rustls::RootCertStore::empty();
-    root_store.add(&rustls::Certificate(cert_der)).unwrap();
+    root_store
+        .add(&rustls::Certificate(cert_der))
+        .expect("add cert");
     let client_config = rustls::ClientConfig::builder()
         .with_safe_defaults()
         .with_root_certificates(root_store)
         .with_no_client_auth();
     let connector = TlsConnector::from(Arc::new(client_config));
-    let tcp = tokio::net::TcpStream::connect(addr).await.unwrap();
-    let server_name = rustls::ServerName::try_from("localhost").unwrap();
-    let mut stream = connector.connect(server_name, tcp).await.unwrap();
+    let tcp = tokio::net::TcpStream::connect(addr).await?;
+    let server_name = rustls::ServerName::try_from("localhost")?;
+    let mut stream = connector.connect(server_name, tcp).await?;
 
-    write_length_prefixed(&mut stream, token.as_bytes())
-        .await
-        .unwrap();
-    let resp = read_length_prefixed(&mut stream).await.unwrap();
+    write_length_prefixed(&mut stream, token.as_bytes()).await?;
+    let resp = read_length_prefixed(&mut stream).await?;
     assert_eq!(&resp[..], b"OK");
     write_length_prefixed(
         &mut stream,
-        &serde_json::to_vec(&NodeMessage::GetConnectedNodes).unwrap(),
+        &serde_json::to_vec(&NodeMessage::GetConnectedNodes)?,
     )
-    .await
-    .unwrap();
-    let msg = read_length_prefixed(&mut stream).await.unwrap();
-    let msg: NodeMessage = serde_json::from_slice(&msg).unwrap();
+    .await?;
+    let msg = read_length_prefixed(&mut stream).await?;
+    let msg: NodeMessage = serde_json::from_slice(&msg)?;
     assert!(matches!(msg, NodeMessage::ConnectedNodes(_)));
     write_length_prefixed(
         &mut stream,
-        &serde_json::to_vec(&NodeMessage::RequestConnection("node1".into())).unwrap(),
+        &serde_json::to_vec(&NodeMessage::RequestConnection("node1".into()))?,
     )
-    .await
-    .unwrap();
-    let msg = read_length_prefixed(&mut stream).await.unwrap();
-    let msg: NodeMessage = serde_json::from_slice(&msg).unwrap();
+    .await?;
+    let msg = read_length_prefixed(&mut stream).await?;
+    let msg: NodeMessage = serde_json::from_slice(&msg)?;
     match msg {
         NodeMessage::ConnectionInfo(_, port) => assert_eq!(port, addr.port() + 1),
         other => panic!("unexpected message: {:?}", other),
     }
 
-    assert!(ports.lock().unwrap().is_empty());
-    server.await.unwrap();
+    assert!(ports.lock().expect("lock ports").is_empty());
+    server.await.expect("server task failed");
+    Ok(())
 }

--- a/CPCluster_node/tests/integration.rs
+++ b/CPCluster_node/tests/integration.rs
@@ -6,10 +6,10 @@ use std::{
 use tokio::net::TcpListener;
 
 #[tokio::test]
-async fn node_interacts_with_master() {
+async fn node_interacts_with_master() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // choose random port for master
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
     let token = "testtoken".to_string();
     let token_srv = token.clone();
     let ports = Arc::new(Mutex::new(HashSet::from([addr.port() + 1])));
@@ -17,61 +17,74 @@ async fn node_interacts_with_master() {
 
     // spawn simplified master server
     let server = tokio::spawn(async move {
-        let (mut socket, _) = listener.accept().await.unwrap();
-        let token_bytes = read_length_prefixed(&mut socket).await.unwrap();
-        assert_eq!(std::str::from_utf8(&token_bytes).unwrap(), token_srv);
-        write_length_prefixed(&mut socket, b"OK").await.unwrap();
-        let msg = read_length_prefixed(&mut socket).await.unwrap();
-        let msg: NodeMessage = serde_json::from_slice(&msg).unwrap();
+        let (mut socket, _) = listener.accept().await.expect("accept connection");
+        let token_bytes = read_length_prefixed(&mut socket).await.expect("read token");
+        assert_eq!(
+            std::str::from_utf8(&token_bytes).expect("valid UTF-8"),
+            token_srv
+        );
+        write_length_prefixed(&mut socket, b"OK")
+            .await
+            .expect("send auth response");
+        let msg = read_length_prefixed(&mut socket)
+            .await
+            .expect("read message");
+        let msg: NodeMessage = serde_json::from_slice(&msg).expect("deserialize message");
         assert!(matches!(msg, NodeMessage::GetConnectedNodes));
         let resp = NodeMessage::ConnectedNodes(vec!["node1".into()]);
-        write_length_prefixed(&mut socket, &serde_json::to_vec(&resp).unwrap())
+        write_length_prefixed(
+            &mut socket,
+            &serde_json::to_vec(&resp).expect("serialize response"),
+        )
+        .await
+        .expect("send connected nodes");
+        let msg = read_length_prefixed(&mut socket)
             .await
-            .unwrap();
-        let msg = read_length_prefixed(&mut socket).await.unwrap();
-        let msg: NodeMessage = serde_json::from_slice(&msg).unwrap();
+            .expect("read connection request");
+        let msg: NodeMessage =
+            serde_json::from_slice(&msg).expect("deserialize connection request");
         if let NodeMessage::RequestConnection(id) = msg {
             let port = {
-                let mut set = ports_srv.lock().unwrap();
-                let p = *set.iter().next().unwrap();
+                let mut set = ports_srv.lock().expect("lock ports");
+                let p = *set.iter().next().expect("port available");
                 set.remove(&p);
                 p
             };
             let resp = NodeMessage::ConnectionInfo(id, port);
-            write_length_prefixed(&mut socket, &serde_json::to_vec(&resp).unwrap())
-                .await
-                .unwrap();
+            write_length_prefixed(
+                &mut socket,
+                &serde_json::to_vec(&resp).expect("serialize connection info"),
+            )
+            .await
+            .expect("send connection info");
         }
     });
 
     // spawn client node
-    let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
-    write_length_prefixed(&mut stream, token.as_bytes())
-        .await
-        .unwrap();
-    let resp = read_length_prefixed(&mut stream).await.unwrap();
+    let mut stream = tokio::net::TcpStream::connect(addr).await?;
+    write_length_prefixed(&mut stream, token.as_bytes()).await?;
+    let resp = read_length_prefixed(&mut stream).await?;
     assert_eq!(&resp[..], b"OK");
     write_length_prefixed(
         &mut stream,
-        &serde_json::to_vec(&NodeMessage::GetConnectedNodes).unwrap(),
+        &serde_json::to_vec(&NodeMessage::GetConnectedNodes)?,
     )
-    .await
-    .unwrap();
-    let msg = read_length_prefixed(&mut stream).await.unwrap();
-    let msg: NodeMessage = serde_json::from_slice(&msg).unwrap();
+    .await?;
+    let msg = read_length_prefixed(&mut stream).await?;
+    let msg: NodeMessage = serde_json::from_slice(&msg)?;
     assert!(matches!(msg, NodeMessage::ConnectedNodes(_)));
     write_length_prefixed(
         &mut stream,
-        &serde_json::to_vec(&NodeMessage::RequestConnection("node1".into())).unwrap(),
+        &serde_json::to_vec(&NodeMessage::RequestConnection("node1".into()))?,
     )
-    .await
-    .unwrap();
-    let msg = read_length_prefixed(&mut stream).await.unwrap();
-    let msg: NodeMessage = serde_json::from_slice(&msg).unwrap();
+    .await?;
+    let msg = read_length_prefixed(&mut stream).await?;
+    let msg: NodeMessage = serde_json::from_slice(&msg)?;
     match msg {
         NodeMessage::ConnectionInfo(_, port) => assert_eq!(port, addr.port() + 1),
         other => panic!("unexpected message: {:?}", other),
     }
-    assert!(ports.lock().unwrap().is_empty());
-    server.await.unwrap();
+    assert!(ports.lock().expect("lock ports").is_empty());
+    server.await.expect("server task failed");
+    Ok(())
 }

--- a/CPCluster_node/tests/reconnect.rs
+++ b/CPCluster_node/tests/reconnect.rs
@@ -6,10 +6,10 @@ use std::time::Duration;
 use tokio::net::TcpListener;
 
 #[tokio::test]
-async fn connect_with_backoff() {
+async fn connect_with_backoff() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // pick unused port then release
-    let tmp = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let port = tmp.local_addr().unwrap().port();
+    let tmp = TcpListener::bind("127.0.0.1:0").await?;
+    let port = tmp.local_addr()?.port();
     drop(tmp);
     let addr = format!("127.0.0.1:{}", port);
     let join = JoinInfo {
@@ -23,19 +23,31 @@ async fn connect_with_backoff() {
 
     tokio::spawn(async move {
         tokio::time::sleep(Duration::from_millis(200)).await;
-        let listener = TcpListener::bind(addr).await.unwrap();
-        let (mut socket, _) = listener.accept().await.unwrap();
-        let token_bytes = read_length_prefixed(&mut socket).await.unwrap();
-        assert_eq!(std::str::from_utf8(&token_bytes).unwrap(), "tok");
-        write_length_prefixed(&mut socket, b"OK").await.unwrap();
-        let _ = read_length_prefixed(&mut socket).await.unwrap(); // RegisterRole
-        let _ = read_length_prefixed(&mut socket).await.unwrap(); // GetConnectedNodes
-        let resp = NodeMessage::ConnectedNodes(Vec::new());
-        write_length_prefixed(&mut socket, &serde_json::to_vec(&resp).unwrap())
+        let listener = TcpListener::bind(addr).await.expect("bind server");
+        let (mut socket, _) = listener.accept().await.expect("accept connection");
+        let token_bytes = read_length_prefixed(&mut socket).await.expect("read token");
+        assert_eq!(
+            std::str::from_utf8(&token_bytes).expect("valid UTF-8"),
+            "tok"
+        );
+        write_length_prefixed(&mut socket, b"OK")
             .await
-            .unwrap();
+            .expect("send OK");
+        let _ = read_length_prefixed(&mut socket)
+            .await
+            .expect("read register role");
+        let _ = read_length_prefixed(&mut socket)
+            .await
+            .expect("read get connected nodes");
+        let resp = NodeMessage::ConnectedNodes(Vec::new());
+        write_length_prefixed(
+            &mut socket,
+            &serde_json::to_vec(&resp).expect("serialize response"),
+        )
+        .await
+        .expect("send connected nodes");
     });
 
-    let res = connect_to_master(&join, &config).await;
-    assert!(res.is_ok());
+    connect_to_master(&join, &config).await?;
+    Ok(())
 }

--- a/CPCluster_node/tests/tls.rs
+++ b/CPCluster_node/tests/tls.rs
@@ -6,9 +6,9 @@ use tokio::net::TcpListener;
 use tokio_rustls::{rustls, TlsAcceptor, TlsConnector};
 
 #[tokio::test]
-async fn node_tls_interaction() {
-    let cert = generate_simple_self_signed(vec!["localhost".into()]).unwrap();
-    let cert_der = cert.serialize_der().unwrap();
+async fn node_tls_interaction() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let cert = generate_simple_self_signed(vec!["localhost".into()])?;
+    let cert_der = cert.serialize_der()?;
     let key_der = cert.serialize_private_key_der();
     let tls_config = rustls::ServerConfig::builder()
         .with_safe_defaults()
@@ -17,87 +17,102 @@ async fn node_tls_interaction() {
             vec![rustls::Certificate(cert_der.clone())],
             rustls::PrivateKey(key_der),
         )
-        .unwrap();
+        .expect("create TLS config");
     let acceptor = TlsAcceptor::from(Arc::new(tls_config));
 
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
     let token = "testtoken".to_string();
     let token_srv = token.clone();
     let ports = Arc::new(Mutex::new(HashSet::from([addr.port() + 1])));
     let ports_srv = ports.clone();
 
     let server = tokio::spawn(async move {
-        let (socket, _) = listener.accept().await.unwrap();
-        let mut socket = acceptor.accept(socket).await.unwrap();
-        let token_bytes = read_length_prefixed(&mut socket).await.unwrap();
-        assert_eq!(std::str::from_utf8(&token_bytes).unwrap(), token_srv);
-        write_length_prefixed(&mut socket, b"OK").await.unwrap();
+        let (socket, _) = listener.accept().await.expect("accept connection");
+        let mut socket = acceptor.accept(socket).await.expect("TLS accept");
+        let token_bytes = read_length_prefixed(&mut socket).await.expect("read token");
+        assert_eq!(
+            std::str::from_utf8(&token_bytes).expect("valid UTF-8"),
+            token_srv
+        );
+        write_length_prefixed(&mut socket, b"OK")
+            .await
+            .expect("send auth response");
 
-        let msg = read_length_prefixed(&mut socket).await.unwrap();
-        let msg: NodeMessage = serde_json::from_slice(&msg).unwrap();
+        let msg = read_length_prefixed(&mut socket)
+            .await
+            .expect("read message");
+        let msg: NodeMessage = serde_json::from_slice(&msg).expect("deserialize message");
         assert!(matches!(msg, NodeMessage::GetConnectedNodes));
         let resp = NodeMessage::ConnectedNodes(vec!["node1".into()]);
-        write_length_prefixed(&mut socket, &serde_json::to_vec(&resp).unwrap())
-            .await
-            .unwrap();
+        write_length_prefixed(
+            &mut socket,
+            &serde_json::to_vec(&resp).expect("serialize response"),
+        )
+        .await
+        .expect("send connected nodes");
 
-        let msg = read_length_prefixed(&mut socket).await.unwrap();
-        let msg: NodeMessage = serde_json::from_slice(&msg).unwrap();
+        let msg = read_length_prefixed(&mut socket)
+            .await
+            .expect("read connection request");
+        let msg: NodeMessage =
+            serde_json::from_slice(&msg).expect("deserialize connection request");
         if let NodeMessage::RequestConnection(id) = msg {
             let port = {
-                let mut set = ports_srv.lock().unwrap();
-                let p = *set.iter().next().unwrap();
+                let mut set = ports_srv.lock().expect("lock ports");
+                let p = *set.iter().next().expect("port available");
                 set.remove(&p);
                 p
             };
             let resp = NodeMessage::ConnectionInfo(id, port);
-            write_length_prefixed(&mut socket, &serde_json::to_vec(&resp).unwrap())
-                .await
-                .unwrap();
+            write_length_prefixed(
+                &mut socket,
+                &serde_json::to_vec(&resp).expect("serialize connection info"),
+            )
+            .await
+            .expect("send connection info");
         }
     });
 
     let mut root_store = rustls::RootCertStore::empty();
-    root_store.add(&rustls::Certificate(cert_der)).unwrap();
+    root_store
+        .add(&rustls::Certificate(cert_der))
+        .expect("add cert");
     let client_config = rustls::ClientConfig::builder()
         .with_safe_defaults()
         .with_root_certificates(root_store)
         .with_no_client_auth();
     let connector = TlsConnector::from(Arc::new(client_config));
-    let tcp = tokio::net::TcpStream::connect(addr).await.unwrap();
-    let server_name = rustls::ServerName::try_from("localhost").unwrap();
-    let mut stream = connector.connect(server_name, tcp).await.unwrap();
+    let tcp = tokio::net::TcpStream::connect(addr).await?;
+    let server_name = rustls::ServerName::try_from("localhost")?;
+    let mut stream = connector.connect(server_name, tcp).await?;
 
-    write_length_prefixed(&mut stream, token.as_bytes())
-        .await
-        .unwrap();
-    let resp = read_length_prefixed(&mut stream).await.unwrap();
+    write_length_prefixed(&mut stream, token.as_bytes()).await?;
+    let resp = read_length_prefixed(&mut stream).await?;
     assert_eq!(&resp[..], b"OK");
 
     write_length_prefixed(
         &mut stream,
-        &serde_json::to_vec(&NodeMessage::GetConnectedNodes).unwrap(),
+        &serde_json::to_vec(&NodeMessage::GetConnectedNodes)?,
     )
-    .await
-    .unwrap();
-    let msg = read_length_prefixed(&mut stream).await.unwrap();
-    let msg: NodeMessage = serde_json::from_slice(&msg).unwrap();
+    .await?;
+    let msg = read_length_prefixed(&mut stream).await?;
+    let msg: NodeMessage = serde_json::from_slice(&msg)?;
     assert!(matches!(msg, NodeMessage::ConnectedNodes(_)));
 
     write_length_prefixed(
         &mut stream,
-        &serde_json::to_vec(&NodeMessage::RequestConnection("node1".into())).unwrap(),
+        &serde_json::to_vec(&NodeMessage::RequestConnection("node1".into()))?,
     )
-    .await
-    .unwrap();
-    let msg = read_length_prefixed(&mut stream).await.unwrap();
-    let msg: NodeMessage = serde_json::from_slice(&msg).unwrap();
+    .await?;
+    let msg = read_length_prefixed(&mut stream).await?;
+    let msg: NodeMessage = serde_json::from_slice(&msg)?;
     match msg {
         NodeMessage::ConnectionInfo(_, port) => assert_eq!(port, addr.port() + 1),
         other => panic!("unexpected message: {:?}", other),
     }
 
-    assert!(ports.lock().unwrap().is_empty());
-    server.await.unwrap();
+    assert!(ports.lock().expect("lock ports").is_empty());
+    server.await.expect("server task failed");
+    Ok(())
 }


### PR DESCRIPTION
## Summary
- use `Result`-returning async tests with `?` for error propagation
- replace raw `unwrap()` calls with `expect()` and contextual messages
- apply changes across master and node integration tests

## Testing
- `cargo clippy --all-targets`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684d155f58c48325b1e3b4e02fcaf26c