### PR TITLE
Add master node integration tests

### DIFF
--- a/CPCluster_masterNode/Cargo.toml
+++ b/CPCluster_masterNode/Cargo.toml
@@ -15,3 +15,6 @@ uuid = { version = "1.0", features = ["v4"] }
 cpcluster_common = { path = "../cpcluster_common" }
 log = "0.4"
 env_logger = "0.10"
+
+[dev-dependencies]
+tempfile = "3"

--- a/CPCluster_masterNode/tests/integration.rs
+++ b/CPCluster_masterNode/tests/integration.rs
@@ -104,3 +104,73 @@ async fn master_node_interaction() -> Result<(), Box<dyn std::error::Error + Sen
     server.await.expect("server task failed");
     Ok(())
 }
+
+#[tokio::test]
+async fn port_released_after_disconnect() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
+    let token = "testtoken".to_string();
+    let token_srv = token.clone();
+
+    let ports = Arc::new(Mutex::new(HashSet::from([addr.port() + 1])));
+    let ports_srv = ports.clone();
+    let released = ports.clone();
+
+    let server = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.expect("accept connection");
+        let token_bytes = read_length_prefixed(&mut socket).await.expect("read token");
+        assert_eq!(
+            std::str::from_utf8(&token_bytes).expect("valid UTF-8"),
+            token_srv
+        );
+        write_length_prefixed(&mut socket, b"OK")
+            .await
+            .expect("send auth");
+
+        let msg = read_length_prefixed(&mut socket)
+            .await
+            .expect("read request");
+        let msg: NodeMessage = serde_json::from_slice(&msg).expect("deserialize");
+        let mut allocated_port = 0u16;
+        if let NodeMessage::RequestConnection(id) = msg {
+            let port = {
+                let mut set = ports_srv.lock().expect("lock ports");
+                let p = *set.iter().next().expect("port available");
+                set.remove(&p);
+                p
+            };
+            allocated_port = port;
+            let resp = NodeMessage::ConnectionInfo(id, port);
+            write_length_prefixed(&mut socket, &serde_json::to_vec(&resp).unwrap())
+                .await
+                .expect("send info");
+        }
+
+        let msg = read_length_prefixed(&mut socket)
+            .await
+            .expect("read disconnect");
+        let msg: NodeMessage = serde_json::from_slice(&msg).expect("deserialize");
+        if matches!(msg, NodeMessage::Disconnect) {
+            released.lock().expect("lock").insert(allocated_port);
+        }
+    });
+
+    let mut stream = tokio::net::TcpStream::connect(addr).await?;
+    write_length_prefixed(&mut stream, token.as_bytes()).await?;
+    read_length_prefixed(&mut stream).await?; // OK
+
+    write_length_prefixed(
+        &mut stream,
+        &serde_json::to_vec(&NodeMessage::RequestConnection("node1".into()))?,
+    )
+    .await?;
+    let _ = read_length_prefixed(&mut stream).await?; // ConnectionInfo
+
+    assert!(ports.lock().expect("lock").is_empty());
+
+    write_length_prefixed(&mut stream, &serde_json::to_vec(&NodeMessage::Disconnect)?).await?;
+
+    server.await.expect("server task");
+    assert!(ports.lock().expect("lock").contains(&(addr.port() + 1)));
+    Ok(())
+}

--- a/CPCluster_masterNode/tests/state_tests.rs
+++ b/CPCluster_masterNode/tests/state_tests.rs
@@ -1,0 +1,46 @@
+use cpcluster_common::Task;
+use cpcluster_masternode::state::{load_state, save_state, MasterNode};
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use tempfile::tempdir;
+
+#[tokio::test]
+async fn master_state_persists_pending_tasks(
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let dir = tempdir()?;
+    let orig = std::env::current_dir()?;
+    std::env::set_current_dir(dir.path())?;
+
+    let master = MasterNode {
+        connected_nodes: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+        available_ports: Arc::new(tokio::sync::Mutex::new(HashSet::new())),
+        failover_timeout_ms: 1000,
+        pending_tasks: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+        completed_tasks: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+    };
+
+    master.pending_tasks.lock().await.insert(
+        "task1".into(),
+        Task::Compute {
+            expression: "1+1".into(),
+        },
+    );
+
+    save_state(&master).await;
+
+    let new_master = MasterNode {
+        connected_nodes: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+        available_ports: Arc::new(tokio::sync::Mutex::new(HashSet::new())),
+        failover_timeout_ms: 1000,
+        pending_tasks: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+        completed_tasks: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+    };
+
+    load_state(&new_master).await;
+
+    let pending = new_master.pending_tasks.lock().await;
+    assert!(pending.contains_key("task1"));
+
+    std::env::set_current_dir(orig)?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add test ensuring ports are released after Disconnect
- add test checking `master_state.json` persistence
- include `tempfile` as dev-dependency for master node tests

## Testing
- `cargo clippy --all-targets`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684d6e71fb508325b2b61d5d6b26c75b