### PR TITLE
Improve TLS error logging

### DIFF
--- a/CPCluster_masterNode/src/lib.rs
+++ b/CPCluster_masterNode/src/lib.rs
@@ -379,7 +379,12 @@ pub async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
                             error!("TLS connection error: {:?}", e);
                         }
                     }
-                    Err(e) => error!("TLS accept failed: {:?}", e),
+                    Err(e) => error!(
+                        "TLS accept from {} failed (kind: {:?}): {}",
+                        addr,
+                        e.kind(),
+                        e
+                    ),
                 }
             } else if let Err(e) =
                 handle_connection(stream, master_node, token, addr.to_string()).await

--- a/CPCluster_node/Cargo.toml
+++ b/CPCluster_node/Cargo.toml
@@ -29,6 +29,7 @@ cpcluster_common = { path = "../cpcluster_common" }
 rustls-native-certs = "0.8"
 log = "0.4"
 env_logger = "0.10"
+sha2 = "0.10"
 
 [dev-dependencies]
 rcgen = "0.9"


### PR DESCRIPTION
## Summary
- log specific TLS handshake errors in node connect and handle_connection
- report peer certificate hashes when TLS succeeds
- show accept error kind on the master side
- test TLS certificate mismatch

## Testing
- `cargo clippy --all-targets`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684d7094c9908325936ad6054b8f9456