### PR TITLE
Centralize execute_task

### DIFF
--- a/CPCluster_node/src/lib.rs
+++ b/CPCluster_node/src/lib.rs
@@ -6,6 +6,7 @@ pub mod disk_store;
 pub mod internet_ports;
 pub mod memory_store;
 pub mod node;
+pub use cpcluster_common::execute_task;
 
 use disk_store::DiskStore;
 use internet_ports::InternetPorts;
@@ -55,7 +56,7 @@ fn eval_complex(expr: &str) -> Result<Complex64, String> {
     stack.pop().ok_or("no result".into())
 }
 
-pub async fn execute_task(
+pub async fn execute_node_task(
     task: Task,
     client: &Client,
     storage_dir: &str,

--- a/CPCluster_node/src/node.rs
+++ b/CPCluster_node/src/node.rs
@@ -1,5 +1,5 @@
 use crate::{
-    disk_store::DiskStore, execute_task, internet_ports::InternetPorts, memory_store::MemoryStore,
+    disk_store::DiskStore, execute_node_task, internet_ports::InternetPorts, memory_store::MemoryStore,
 };
 use cpcluster_common::config::Config;
 use cpcluster_common::{
@@ -159,7 +159,7 @@ async fn heartbeat_loop(
                             info!("Received heartbeat acknowledgement from master");
                         }
                         NodeMessage::AssignTask { id, task } => {
-                            let result = execute_task(
+                            let result = execute_node_task(
                                 task,
                                 &http_client,
                                 &config.storage_dir,
@@ -455,7 +455,7 @@ async fn handle_connection(
             Err(_) => break,
         };
         if let Ok(NodeMessage::AssignTask { id, task }) = serde_json::from_slice(&buf) {
-            let result = execute_task(
+            let result = execute_node_task(
                 task,
                 &client,
                 storage_dir,

--- a/cpcluster_client/Cargo.toml
+++ b/cpcluster_client/Cargo.toml
@@ -12,4 +12,3 @@ serde_json = "1.0"
 env_logger = "0.10"
 log = "0.4"
 reqwest = { version = "0.11", features = ["rustls-tls"] }
-meval = "0.2"

--- a/cpcluster_client/src/lib.rs
+++ b/cpcluster_client/src/lib.rs
@@ -1,8 +1,6 @@
 use cpcluster_common::{
     NodeMessage, Task, TaskResult, read_length_prefixed, write_length_prefixed,
 };
-use meval::eval_str;
-use reqwest::Client;
 use std::error::Error;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::time::{Duration, sleep};
@@ -33,19 +31,4 @@ where
     }
 }
 
-pub async fn execute_task(task: Task, client: &Client) -> TaskResult {
-    match task {
-        Task::Compute { expression } => match eval_str(&expression) {
-            Ok(v) => TaskResult::Number(v),
-            Err(e) => TaskResult::Error(e.to_string()),
-        },
-        Task::HttpRequest { url } => match client.get(&url).send().await {
-            Ok(resp) => match resp.text().await {
-                Ok(text) => TaskResult::Response(text),
-                Err(e) => TaskResult::Error(e.to_string()),
-            },
-            Err(e) => TaskResult::Error(e.to_string()),
-        },
-        _ => TaskResult::Error("Unsupported task".into()),
-    }
-}
+pub use cpcluster_common::execute_task;

--- a/cpcluster_common/Cargo.toml
+++ b/cpcluster_common/Cargo.toml
@@ -7,3 +7,5 @@ edition = "2021"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["full"] }
+reqwest = { version = "0.11", features = ["rustls-tls"] }
+meval = "0.2"

--- a/cpcluster_common/src/execute.rs
+++ b/cpcluster_common/src/execute.rs
@@ -1,0 +1,21 @@
+use crate::{Task, TaskResult};
+use meval::eval_str;
+use reqwest::Client;
+
+/// Execute simple tasks that don't require node-specific resources.
+pub async fn execute_task(task: Task, client: &Client) -> TaskResult {
+    match task {
+        Task::Compute { expression } => match eval_str(&expression) {
+            Ok(v) => TaskResult::Number(v),
+            Err(e) => TaskResult::Error(e.to_string()),
+        },
+        Task::HttpRequest { url } => match client.get(&url).send().await {
+            Ok(resp) => match resp.text().await {
+                Ok(text) => TaskResult::Response(text),
+                Err(e) => TaskResult::Error(e.to_string()),
+            },
+            Err(e) => TaskResult::Error(e.to_string()),
+        },
+        _ => TaskResult::Error("Unsupported task".into()),
+    }
+}

--- a/cpcluster_common/src/lib.rs
+++ b/cpcluster_common/src/lib.rs
@@ -3,6 +3,8 @@ use std::borrow::Cow;
 
 pub mod config;
 pub use config::Config;
+pub mod execute;
+pub use execute::execute_task;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
 pub enum NodeRole {


### PR DESCRIPTION
## Summary
- share execute_task implementation in cpcluster_common
- re-export in node and client crates
- rename node-specific implementation to `execute_node_task`
- clean up dependencies

## Testing
- `cargo fmt`
- `cargo clippy --all-targets`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684d7aae58308325a27d4227e06f1923