### PR TITLE
Expand master README

### DIFF
--- a/CPCluster_masterNode/README.md
+++ b/CPCluster_masterNode/README.md
@@ -4,6 +4,27 @@ This crate implements the CPCluster master connection manager. It listens for TC
 
 On startup the master generates a `join.json` file containing the token, its IP address and port. Nodes must provide this token when connecting. Set `CPCLUSTER_JOIN` before starting the master to control where this file is written.
 
+## Running
+
+```bash
+cargo run -- <config-path>
+```
+
+Replace `<config-path>` with the path to your configuration file if it is not `config.json`. The master listens on port **55000** and manages connection requests from nodes.
+
+When starting, the master writes `join.json` with the authentication token. Restrict access to this file (for example `chmod 600`) and consider encrypting it before copying to nodes. You can also provide the token via the `CPCLUSTER_TOKEN` environment variable instead of copying the file.
+
+### Master Shell
+
+After startup the master opens an interactive shell. Useful commands include:
+
+```
+nodes             # list connected nodes
+tasks             # list queued tasks
+task <id>         # inspect a specific task
+addtask <type> <args>  # queue a new task
+```
+
 ## Responsibilities
 
 - Maintain a map of currently connected nodes along with their addresses.


### PR DESCRIPTION
## Summary
- document how to run the master with `cargo run -- <config-path>`
- add notes on `join.json` security and available shell commands

## Testing
- `cargo fmt`
- `cargo clippy --all-targets`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684dcea6268c8325bf053661a2583b26