### PR TITLE
Implement timeout for submit_and_wait

### DIFF
--- a/cpcluster_client/README.md
+++ b/cpcluster_client/README.md
@@ -2,7 +2,8 @@
 
 This crate provides a simple example client that submits compute tasks to the
 master node and waits for the result. It demonstrates how compute tasks can
-borrow string slices using `Cow`.
+borrow string slices using `Cow`. Each call to `submit_and_wait` accepts an
+optional timeout (default 5 seconds) so tasks won't block forever.
 
 ## Running
 

--- a/cpcluster_client/src/lib.rs
+++ b/cpcluster_client/src/lib.rs
@@ -3,16 +3,21 @@ use cpcluster_common::{
 };
 use std::error::Error;
 use tokio::io::{AsyncRead, AsyncWrite};
-use tokio::time::{Duration, sleep};
+use tokio::time::{Duration, Instant, sleep, timeout};
 use uuid::Uuid;
+
+/// Default timeout applied when [`submit_and_wait`] callers pass `None`.
+pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub async fn submit_and_wait<S>(
     stream: &mut S,
     task: Task,
+    timeout_duration: Option<Duration>,
 ) -> Result<TaskResult, Box<dyn Error + Send + Sync>>
 where
     S: AsyncRead + AsyncWrite + Unpin,
 {
+    let timeout_duration = timeout_duration.unwrap_or(DEFAULT_TIMEOUT);
     let id = Uuid::new_v4().to_string();
     let msg = NodeMessage::SubmitTask {
         id: id.clone(),
@@ -20,13 +25,26 @@ where
     };
     write_length_prefixed(stream, &serde_json::to_vec(&msg)?).await?;
     let _ = read_length_prefixed(stream).await?; // TaskAccepted
+    let deadline = Instant::now() + timeout_duration;
     loop {
         let req = NodeMessage::GetTaskResult(id.clone());
         write_length_prefixed(stream, &serde_json::to_vec(&req)?).await?;
-        let buf = read_length_prefixed(stream).await?;
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return Err("task timed out".into());
+        }
+        let buf = match timeout(remaining, read_length_prefixed(stream)).await {
+            Ok(res) => res?,
+            Err(_) => return Err("task timed out".into()),
+        };
         match serde_json::from_slice::<NodeMessage>(&buf)? {
             NodeMessage::TaskResult { result, .. } => return Ok(result),
-            _ => sleep(Duration::from_millis(500)).await,
+            _ => {
+                if Instant::now() >= deadline {
+                    return Err("task timed out".into());
+                }
+                sleep(Duration::from_millis(500)).await
+            }
         }
     }
 }

--- a/cpcluster_client/src/main.rs
+++ b/cpcluster_client/src/main.rs
@@ -1,4 +1,4 @@
-use cpcluster_client::{execute_task, submit_and_wait};
+use cpcluster_client::{DEFAULT_TIMEOUT, execute_task, submit_and_wait};
 use cpcluster_common::{
     JoinInfo, NodeMessage, Task, TaskResult, read_length_prefixed, write_length_prefixed,
 };
@@ -19,6 +19,7 @@ async fn run_data_tests(stream: &mut TcpStream) -> Result<(), Box<dyn Error + Se
         Task::Compute {
             expression: Cow::Borrowed("1+1"),
         },
+        Some(DEFAULT_TIMEOUT),
     )
     .await?;
 
@@ -34,6 +35,7 @@ async fn run_data_tests(stream: &mut TcpStream) -> Result<(), Box<dyn Error + Se
             key: mem_id.clone(),
             data: number.to_string().into_bytes(),
         },
+        Some(DEFAULT_TIMEOUT),
     )
     .await?;
 
@@ -45,6 +47,7 @@ async fn run_data_tests(stream: &mut TcpStream) -> Result<(), Box<dyn Error + Se
             path: disk_id.clone(),
             data: content.into_bytes(),
         },
+        Some(DEFAULT_TIMEOUT),
     )
     .await?;
 

--- a/cpcluster_client/tests/integration.rs
+++ b/cpcluster_client/tests/integration.rs
@@ -1,4 +1,4 @@
-use cpcluster_client::{execute_task, submit_and_wait};
+use cpcluster_client::{DEFAULT_TIMEOUT, execute_task, submit_and_wait};
 use cpcluster_common::{
     NodeMessage, Task, TaskResult, read_length_prefixed, write_length_prefixed,
 };
@@ -37,7 +37,9 @@ async fn submit_and_wait_returns_result() {
         expression: Cow::Borrowed("2+3"),
     };
 
-    let res = submit_and_wait(&mut client_stream, task).await.unwrap();
+    let res = submit_and_wait(&mut client_stream, task, Some(DEFAULT_TIMEOUT))
+        .await
+        .unwrap();
     server.await.unwrap();
     match res {
         TaskResult::Number(v) => assert!((v - 5.0).abs() < f64::EPSILON),


### PR DESCRIPTION
## Summary
- support optional timeout in `submit_and_wait`
- update main example and tests to provide a timeout

## Testing
- `cargo clippy --all-targets`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684dd227814c8325bb2ec9e2e745936a