### PR TITLE
Add log-level CLI flag

### DIFF
--- a/CPCluster_masterNode/src/lib.rs
+++ b/CPCluster_masterNode/src/lib.rs
@@ -310,7 +310,6 @@ where
 }
 
 pub async fn run(config_path: &str, join_path: &str) -> Result<(), Box<dyn Error + Send + Sync>> {
-    env_logger::init();
     let config = Config::load(config_path).unwrap_or_default();
     config.save(config_path)?;
     let token = generate_token();
@@ -397,5 +396,8 @@ pub async fn run(config_path: &str, join_path: &str) -> Result<(), Box<dyn Error
 }
 
 pub async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
+    env_logger::Builder::new()
+        .filter_level(log::LevelFilter::Info)
+        .init();
     run("config.json", "join.json").await
 }

--- a/CPCluster_masterNode/src/main.rs
+++ b/CPCluster_masterNode/src/main.rs
@@ -1,5 +1,28 @@
 fn parse_config_path<I: Iterator<Item = String>>(mut args: I) -> String {
-    args.nth(1).unwrap_or_else(|| "config.json".to_string())
+    args.next();
+    for arg in args {
+        if !arg.starts_with("--") {
+            return arg;
+        }
+    }
+    "config.json".to_string()
+}
+
+fn parse_log_level<I: Iterator<Item = String>>(mut args: I) -> log::LevelFilter {
+    args.next();
+    let mut expect_level = false;
+    while let Some(arg) = args.next() {
+        if expect_level {
+            return arg.parse().unwrap_or(log::LevelFilter::Info);
+        }
+        if let Some(level) = arg.strip_prefix("--log-level=") {
+            return level.parse().unwrap_or(log::LevelFilter::Info);
+        }
+        if arg == "--log-level" {
+            expect_level = true;
+        }
+    }
+    log::LevelFilter::Info
 }
 
 fn join_path() -> String {
@@ -8,14 +31,17 @@ fn join_path() -> String {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let config_path = parse_config_path(std::env::args());
+    let args: Vec<String> = std::env::args().collect();
+    let config_path = parse_config_path(args.clone().into_iter());
+    let level = parse_log_level(args.into_iter());
+    env_logger::Builder::new().filter_level(level).init();
     let join = join_path();
     cpcluster_masternode::run(&config_path, &join).await
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{join_path, parse_config_path};
+    use super::{join_path, parse_config_path, parse_log_level};
 
     #[test]
     fn default_path() {
@@ -30,6 +56,16 @@ mod tests {
     }
 
     #[test]
+    fn config_after_flag() {
+        let args = vec![
+            "prog".to_string(),
+            "--log-level=debug".to_string(),
+            "master.json".to_string(),
+        ];
+        assert_eq!(parse_config_path(args.into_iter()), "master.json");
+    }
+
+    #[test]
     fn join_env_default() {
         std::env::remove_var("CPCLUSTER_JOIN");
         assert_eq!(join_path(), "join.json");
@@ -40,5 +76,21 @@ mod tests {
         std::env::set_var("CPCLUSTER_JOIN", "data/join.json");
         assert_eq!(join_path(), "data/join.json");
         std::env::remove_var("CPCLUSTER_JOIN");
+    }
+
+    #[test]
+    fn log_level_flag() {
+        let args = vec![
+            "prog".to_string(),
+            "--log-level".to_string(),
+            "debug".to_string(),
+        ];
+        assert_eq!(parse_log_level(args.into_iter()), log::LevelFilter::Debug);
+    }
+
+    #[test]
+    fn log_level_equals() {
+        let args = vec!["prog".to_string(), "--log-level=error".to_string()];
+        assert_eq!(parse_log_level(args.into_iter()), log::LevelFilter::Error);
     }
 }

--- a/README.md
+++ b/README.md
@@ -105,18 +105,20 @@ OpenSSL development libraries manually before building.
 
 1. **Start the Master Node**:
    ```bash
-   cd CPCluster_masterNode
-   cargo run -- <config-path>
-   ```
-   Replace `<config-path>` with the path to your configuration file if it is not `config.json`. The master node listens on port **55000** and manages all connection requests from nodes.
+    cd CPCluster_masterNode
+    cargo run -- <config-path> [--log-level <level>]
+    ```
+    Replace `<config-path>` with the path to your configuration file if it is not `config.json`. The master node listens on port **55000** and manages all connection requests from nodes.
+   The `--log-level` flag controls verbosity (`error`, `warn`, `info`, `debug`, `trace`).
 
 2. **Start Normal Nodes**:
    For each node instance:
    ```bash
    cd CPCluster_node
-   cargo run -- <config-path>
+   cargo run -- <config-path> [--log-level <level>]
    ```
    Use `<config-path>` to specify a custom configuration file if needed. The node connects to the master, requests the list of currently connected nodes, and can initiate direct connections to other nodes.
+   The `--log-level` flag controls verbosity in the same way as for the master.
 
 ### Example Workflow
 


### PR DESCRIPTION
## Summary
- allow specifying `--log-level` for both node and master binaries
- remove env_logger init from masternode library and set default logging level
- document the new option in the README

## Testing
- `cargo clippy --all-targets`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684dd99e62088325bf42f78645adafc2