### PR TITLE
Optimize node storage and port management

### DIFF
--- a/CPCluster_masterNode/tests/state_tests.rs
+++ b/CPCluster_masterNode/tests/state_tests.rs
@@ -1,6 +1,6 @@
 use cpcluster_common::Task;
 use cpcluster_masternode::state::{load_state, save_state, MasterNode};
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use tempfile::tempdir;
 
@@ -12,7 +12,7 @@ async fn master_state_persists_pending_tasks(
 
     let master = MasterNode {
         connected_nodes: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
-        available_ports: Arc::new(tokio::sync::Mutex::new(HashSet::new())),
+        available_ports: Arc::new(tokio::sync::Mutex::new(VecDeque::new())),
         failover_timeout_ms: 1000,
         pending_tasks: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
         completed_tasks: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
@@ -30,7 +30,7 @@ async fn master_state_persists_pending_tasks(
 
     let new_master = MasterNode {
         connected_nodes: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
-        available_ports: Arc::new(tokio::sync::Mutex::new(HashSet::new())),
+        available_ports: Arc::new(tokio::sync::Mutex::new(VecDeque::new())),
         failover_timeout_ms: 1000,
         pending_tasks: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
         completed_tasks: Arc::new(tokio::sync::Mutex::new(HashMap::new())),

--- a/CPCluster_node/Cargo.toml
+++ b/CPCluster_node/Cargo.toml
@@ -30,6 +30,7 @@ rustls-native-certs = "0.8"
 log = "0.4"
 env_logger = "0.10"
 sha2 = "0.10"
+dashmap = "5"
 
 [dev-dependencies]
 rcgen = "0.9"

--- a/CPCluster_node/src/disk_store.rs
+++ b/CPCluster_node/src/disk_store.rs
@@ -1,27 +1,38 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use tokio::fs;
 
 #[derive(Clone)]
 pub struct DiskStore {
     dir: PathBuf,
     quota_bytes: u64,
+    usage: Arc<AtomicU64>,
 }
 
 impl DiskStore {
     pub fn new(dir: PathBuf, quota_mb: u64) -> Self {
+        let usage = directory_size_sync(&dir).unwrap_or(0);
         Self {
             dir,
             quota_bytes: quota_mb * 1024 * 1024,
+            usage: Arc::new(AtomicU64::new(usage)),
         }
     }
 
     pub async fn store(&self, id: String, data: Vec<u8>) -> std::io::Result<()> {
         fs::create_dir_all(&self.dir).await?;
-        let usage = directory_size_async(self.dir.clone()).await?;
-        if usage + data.len() as u64 > self.quota_bytes {
+        let path = self.dir.join(&id);
+        let old_size = fs::metadata(&path).await.ok().map(|m| m.len()).unwrap_or(0);
+        let data_len = data.len() as u64;
+        let new_usage = self.usage.load(Ordering::SeqCst).saturating_sub(old_size) + data_len;
+        if new_usage > self.quota_bytes {
             return Err(std::io::Error::other("quota exceeded"));
         }
-        fs::write(self.dir.join(id), data).await
+        fs::write(&path, &data).await?;
+        self.usage
+            .fetch_add(data_len.saturating_sub(old_size), Ordering::SeqCst);
+        Ok(())
     }
 
     pub async fn load(&self, id: &str) -> Option<Vec<u8>> {
@@ -39,22 +50,22 @@ impl DiskStore {
                 entries.push((entry.file_name().to_string_lossy().to_string(), meta.len()));
             }
         }
-        let used = directory_size_async(self.dir.clone()).await?;
+        let used = self.usage.load(Ordering::SeqCst);
         let free = self.quota_bytes.saturating_sub(used);
         Ok((entries, free))
     }
 }
 
-async fn directory_size_async(path: PathBuf) -> std::io::Result<u64> {
-    if !fs::try_exists(&path).await? {
+fn directory_size_sync(path: &Path) -> std::io::Result<u64> {
+    if !path.exists() {
         return Ok(0);
     }
     let mut size = 0u64;
-    let mut stack = vec![path];
+    let mut stack = vec![path.to_path_buf()];
     while let Some(dir_path) = stack.pop() {
-        let mut dir = fs::read_dir(dir_path).await?;
-        while let Some(entry) = dir.next_entry().await? {
-            let meta = entry.metadata().await?;
+        for entry in std::fs::read_dir(&dir_path)? {
+            let entry = entry?;
+            let meta = entry.metadata()?;
             if meta.is_file() {
                 size += meta.len();
             } else if meta.is_dir() {


### PR DESCRIPTION
## Summary
- speed up the in-memory store with `DashMap`
- cache disk usage in `DiskStore`
- manage available ports with `VecDeque`
- update tests for new types

## Testing
- `cargo clippy --all-targets`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684dda3adaf08325ba9d19b354e0f237