### PR TITLE
Fix shell stats commands

### DIFF
--- a/CPCluster_masterNode/src/shell.rs
+++ b/CPCluster_masterNode/src/shell.rs
@@ -133,17 +133,35 @@ pub fn run_shell(master: Arc<MasterNode>, rt: Handle) {
                     }
                 }
                 "getglobalram" => {
-                    match rt.block_on(submit_task_and_wait(&master, Task::GetGlobalRam, 5000)) {
-                        Some(TaskResult::Response(r)) => println!("{}", r.trim()),
-                        Some(TaskResult::Error(e)) => println!("Error: {}", e),
-                        _ => println!("Failed to retrieve RAM stats"),
+                    let has_worker = master
+                        .connected_nodes
+                        .blocking_lock()
+                        .values()
+                        .any(|n| matches!(n.role, cpcluster_common::NodeRole::Worker));
+                    if !has_worker {
+                        println!("No worker nodes available");
+                    } else {
+                        match rt.block_on(submit_task_and_wait(&master, Task::GetGlobalRam, 5000)) {
+                            Some(TaskResult::Response(r)) => println!("{}", r.trim()),
+                            Some(TaskResult::Error(e)) => println!("Error: {}", e),
+                            _ => println!("Failed to retrieve RAM stats"),
+                        }
                     }
                 }
                 "getstorage" => {
-                    match rt.block_on(submit_task_and_wait(&master, Task::GetStorage, 5000)) {
-                        Some(TaskResult::Response(r)) => println!("{}", r.trim()),
-                        Some(TaskResult::Error(e)) => println!("Error: {}", e),
-                        _ => println!("Failed to retrieve storage stats"),
+                    let has_disk = master
+                        .connected_nodes
+                        .blocking_lock()
+                        .values()
+                        .any(|n| matches!(n.role, cpcluster_common::NodeRole::Disk));
+                    if !has_disk {
+                        println!("No disk nodes available");
+                    } else {
+                        match rt.block_on(submit_task_and_wait(&master, Task::GetStorage, 5000)) {
+                            Some(TaskResult::Response(r)) => println!("{}", r.trim()),
+                            Some(TaskResult::Error(e)) => println!("Error: {}", e),
+                            _ => println!("Failed to retrieve storage stats"),
+                        }
                     }
                 }
                 "exit" | "quit" => {


### PR DESCRIPTION
## Summary
- check for worker/disk roles before sending GetGlobalRam/GetStorage tasks

## Testing
- `cargo clippy --all-targets --quiet`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_684dde34af0c8325a7f56f8398a286f6