### PR TITLE
Improve nodes command output

### DIFF
--- a/CPCluster_masterNode/README.md
+++ b/CPCluster_masterNode/README.md
@@ -19,7 +19,7 @@ When starting, the master writes `join.json` with the authentication token. Rest
 After startup the master opens an interactive shell. Useful commands include:
 
 ```
-nodes             # list connected nodes
+nodes             # list connected nodes with their role
 tasks             # list queued tasks
 task <id>         # inspect a specific task
 addtask <type> <args>  # queue a new task

--- a/CPCluster_masterNode/src/shell.rs
+++ b/CPCluster_masterNode/src/shell.rs
@@ -31,7 +31,7 @@ async fn submit_task_and_wait(
 
 pub fn run_shell(master: Arc<MasterNode>, rt: Handle) {
     use std::io::{self, BufRead, Write};
-    println!("CPCluster shell ready.\nCommands:\n  nodes                - list connected nodes\n  tasks                - list active and pending tasks\n  task <id>           - show status or result of a task\n  addtask <type> <arg> - queue a task (type: compute|http)\n  getglobalram         - show memory usage of a worker\n  getstorage           - show disk usage of a disk node\n  exit                 - quit");
+    println!("CPCluster shell ready.\nCommands:\n  nodes                - list connected nodes with their role\n  tasks                - list active and pending tasks\n  task <id>           - show status or result of a task\n  addtask <type> <arg> - queue a task (type: compute|http)\n  getglobalram         - show memory usage of a worker\n  getstorage           - show disk usage of a disk node\n  exit                 - quit");
     let stdin = io::stdin();
     let mut lines = stdin.lock().lines();
     print!("> ");
@@ -45,8 +45,8 @@ pub fn run_shell(master: Arc<MasterNode>, rt: Handle) {
                     if nodes.is_empty() {
                         println!("No connected nodes");
                     } else {
-                        for addr in nodes.keys() {
-                            println!("{}", addr);
+                        for (addr, info) in nodes.iter() {
+                            println!("{} ({:?})", addr, info.role);
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- display node roles in the `nodes` command output
- mention node roles in shell help text and README

## Testing
- `cargo clippy --all-targets`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684de5320f8c8325a4e0dbb78248dec2