### PR TITLE
Improve CPCluster performance

### DIFF
--- a/CPCluster_masterNode/src/lib.rs
+++ b/CPCluster_masterNode/src/lib.rs
@@ -19,7 +19,7 @@ pub mod state;
 pub mod tls;
 
 use shell::run_shell;
-use state::{load_state, save_state, spawn_save_state, MasterNode, NodeInfo};
+use state::{load_state, spawn_save_state, MasterNode, NodeInfo};
 use tls::load_or_generate_tls_config;
 
 async fn send_pending_tasks<S>(
@@ -364,7 +364,7 @@ pub async fn run(config_path: &str, join_path: &str) -> Result<(), Box<dyn Error
         }
     });
     loop {
-        let (mut stream, addr) = listener.accept().await?;
+        let (stream, addr) = listener.accept().await?;
         let _ = stream.set_nodelay(true);
         let master_node = Arc::clone(&master_node);
         let token = token.clone();

--- a/CPCluster_masterNode/src/state.rs
+++ b/CPCluster_masterNode/src/state.rs
@@ -64,3 +64,11 @@ pub async fn save_state(master: &MasterNode) {
         let _ = tokio::fs::write(&master.state_file, data).await;
     }
 }
+
+/// Write the master state to disk asynchronously without blocking the caller.
+pub fn spawn_save_state(master: &Arc<MasterNode>) {
+    let m = Arc::clone(master);
+    tokio::spawn(async move {
+        save_state(&m).await;
+    });
+}

--- a/CPCluster_node/src/disk_store.rs
+++ b/CPCluster_node/src/disk_store.rs
@@ -12,6 +12,7 @@ pub struct DiskStore {
 
 impl DiskStore {
     pub fn new(dir: PathBuf, quota_mb: u64) -> Self {
+        std::fs::create_dir_all(&dir).ok();
         let usage = directory_size_sync(&dir).unwrap_or(0);
         Self {
             dir,
@@ -21,7 +22,6 @@ impl DiskStore {
     }
 
     pub async fn store(&self, id: String, data: Vec<u8>) -> std::io::Result<()> {
-        fs::create_dir_all(&self.dir).await?;
         let path = self.dir.join(&id);
         let old_size = fs::metadata(&path).await.ok().map(|m| m.len()).unwrap_or(0);
         let data_len = data.len() as u64;
@@ -41,7 +41,6 @@ impl DiskStore {
 
     /// Return a list of all stored files with their size in bytes and the remaining free space
     pub async fn stats(&self) -> std::io::Result<(Vec<(String, u64)>, u64)> {
-        fs::create_dir_all(&self.dir).await?;
         let mut entries = Vec::new();
         let mut dir = fs::read_dir(&self.dir).await?;
         while let Some(entry) = dir.next_entry().await? {

--- a/CPCluster_node/src/lib.rs
+++ b/CPCluster_node/src/lib.rs
@@ -76,15 +76,39 @@ pub async fn execute_node_task(
                         if s.bind(std::net::SocketAddr::from(([0, 0, 0, 0], inet)))
                             .is_ok()
                         {
-                            s.connect(addr.parse().unwrap()).await
+                            match s.connect(addr.parse().unwrap()).await {
+                                Ok(stream) => {
+                                    let _ = stream.set_nodelay(true);
+                                    Ok(stream)
+                                }
+                                Err(e) => Err(e),
+                            }
                         } else {
-                            TcpStream::connect(&addr).await
+                            match TcpStream::connect(&addr).await {
+                                Ok(stream) => {
+                                    let _ = stream.set_nodelay(true);
+                                    Ok(stream)
+                                }
+                                Err(e) => Err(e),
+                            }
                         }
                     }
-                    Err(_) => TcpStream::connect(&addr).await,
+                    Err(_) => match TcpStream::connect(&addr).await {
+                        Ok(stream) => {
+                            let _ = stream.set_nodelay(true);
+                            Ok(stream)
+                        }
+                        Err(e) => Err(e),
+                    },
                 }
             } else {
-                TcpStream::connect(&addr).await
+                match TcpStream::connect(&addr).await {
+                    Ok(stream) => {
+                        let _ = stream.set_nodelay(true);
+                        Ok(stream)
+                    }
+                    Err(e) => Err(e),
+                }
             };
             match connect_res {
                 Ok(mut stream) => {

--- a/CPCluster_node/src/node.rs
+++ b/CPCluster_node/src/node.rs
@@ -373,7 +373,7 @@ async fn handle_connection(
     let connect_fut = TcpStream::connect(&addr);
     let mut stream: Box<dyn ReadWrite + Unpin + Send>;
     tokio::select! {
-        Ok(mut sock) = connect_fut => {
+        Ok(sock) = connect_fut => {
             let _ = sock.set_nodelay(true);
             if use_tls {
                 let config = build_tls_config(ca_path, ca_cert)?;
@@ -412,7 +412,7 @@ async fn handle_connection(
                 stream = Box::new(sock);
             }
         }
-        Ok((mut sock, _)) = listener.accept() => {
+        Ok((sock, _)) = listener.accept() => {
             let _ = sock.set_nodelay(true);
             if use_tls {
                 let config = build_tls_config(ca_path, ca_cert)?;

--- a/cpcluster_client/src/main.rs
+++ b/cpcluster_client/src/main.rs
@@ -67,6 +67,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let addr = format!("{}:{}", join_info.ip, join_info.port);
     info!("Connecting to master at {}", addr);
     let mut stream = TcpStream::connect(&addr).await?;
+    let _ = stream.set_nodelay(true);
 
     write_length_prefixed(&mut stream, join_info.token.as_bytes()).await?;
     let resp = read_length_prefixed(&mut stream).await?;


### PR DESCRIPTION
## Summary
- write state on a background task
- create storage directory once and skip re-creating it
- enable TCP_NODELAY on connections for lower latency

## Testing
- `cargo clippy --all-targets`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684de7a83edc8325bf5f6776494803b7