### PR TITLE
Refactor config layout

### DIFF
--- a/CPCluster_masterNode/AGENTS.md
+++ b/CPCluster_masterNode/AGENTS.md
@@ -3,6 +3,6 @@
 This directory contains the master node of the cluster. Source code resides in `src` and integration tests in `tests`.
 
 - Run `cargo run` here to start the master for development.
-- Adjust runtime options in `../config.json`.
+- Adjust runtime options in `config/config.json`.
 - After changes, execute `cargo test` from the repository root.
 

--- a/CPCluster_masterNode/README.md
+++ b/CPCluster_masterNode/README.md
@@ -10,7 +10,7 @@ On startup the master generates a `join.json` file containing the token, its IP 
 cargo run -- <config-path>
 ```
 
-Replace `<config-path>` with the path to your configuration file if it is not `config.json`. The master listens on port **55000** and manages connection requests from nodes.
+Replace `<config-path>` with the path to your configuration file if it is not `config/config.json`. The master listens on port **55000** and manages connection requests from nodes.
 
 When starting, the master writes `join.json` with the authentication token. Restrict access to this file (for example `chmod 600`) and consider encrypting it before copying to nodes. You can also provide the token via the `CPCLUSTER_TOKEN` environment variable instead of copying the file.
 

--- a/CPCluster_masterNode/config/config.json
+++ b/CPCluster_masterNode/config/config.json
@@ -1,14 +1,16 @@
 {
   "min_port": 55001,
   "max_port": 55999,
-  "failover_timeout_ms": 5000,
-  "master_addresses": ["127.0.0.1:55000"],
+  "failover_timeout_ms": 7000,
+  "master_addresses": [
+    "127.0.0.1:55000"
+  ],
   "ca_cert_path": null,
   "ca_cert": null,
   "cert_path": null,
   "key_path": null,
-  "storage_dir": "storage",
+  "storage_dir": "data/storage",
   "state_file": "master_state.json",
-  "max_retries": 5,
-  "log_level": "info"
+  "max_retries": 3,
+  "log_level": "debug"
 }

--- a/CPCluster_masterNode/src/lib.rs
+++ b/CPCluster_masterNode/src/lib.rs
@@ -398,12 +398,12 @@ pub async fn run(config_path: &str, join_path: &str) -> Result<(), Box<dyn Error
 }
 
 pub async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
-    let config = Config::load("config.json").unwrap_or_default();
+    let config = Config::load("CPCluster_masterNode/config/config.json").unwrap_or_default();
     let level = config
         .log_level
         .as_deref()
         .and_then(|l| l.parse().ok())
         .unwrap_or(log::LevelFilter::Info);
     env_logger::Builder::new().filter_level(level).init();
-    run("config.json", "join.json").await
+    run("CPCluster_masterNode/config/config.json", "join.json").await
 }

--- a/CPCluster_masterNode/src/main.rs
+++ b/CPCluster_masterNode/src/main.rs
@@ -5,7 +5,7 @@ fn parse_config_path<I: Iterator<Item = String>>(mut args: I) -> String {
             return arg;
         }
     }
-    "config.json".to_string()
+    "CPCluster_masterNode/config/config.json".to_string()
 }
 
 fn parse_log_level<I: Iterator<Item = String>>(mut args: I) -> Option<log::LevelFilter> {
@@ -50,7 +50,10 @@ mod tests {
     #[test]
     fn default_path() {
         let args = vec!["prog".to_string()];
-        assert_eq!(parse_config_path(args.into_iter()), "config.json");
+        assert_eq!(
+            parse_config_path(args.into_iter()),
+            "CPCluster_masterNode/config/config.json"
+        );
     }
 
     #[test]

--- a/CPCluster_node/AGENTS.md
+++ b/CPCluster_node/AGENTS.md
@@ -3,6 +3,6 @@
 This crate implements a cluster node. Source files live in `src` and tests in `tests`.
 
 - Start a node with `cargo run` after copying `join.json` from the master directory.
-- Configuration is shared via `../config.json`.
+- Configuration is shared via `config/config.json`.
 - Run `cargo test` at the workspace root after modifying the code.
 

--- a/CPCluster_node/README.md
+++ b/CPCluster_node/README.md
@@ -4,7 +4,7 @@
 
 ## Configuration
 
-The node loads runtime options from `config.json` in the current directory. Pass a different file path as the first command line argument to `cargo run` to override it.
+The node loads runtime options from `config/config.json` in the crate directory. Pass a different file path as the first command line argument to `cargo run` to override it.
 
 Key fields include:
 

--- a/CPCluster_node/config/config.json
+++ b/CPCluster_node/config/config.json
@@ -1,0 +1,16 @@
+{
+  "min_port": 55001,
+  "max_port": 55999,
+  "failover_timeout_ms": 7000,
+  "master_addresses": [
+    "127.0.0.1:55000"
+  ],
+  "ca_cert_path": null,
+  "ca_cert": null,
+  "cert_path": null,
+  "key_path": null,
+  "storage_dir": "data/storage",
+  "state_file": "master_state.json",
+  "max_retries": 3,
+  "log_level": "debug"
+}

--- a/CPCluster_node/src/main.rs
+++ b/CPCluster_node/src/main.rs
@@ -10,7 +10,7 @@ fn parse_config_path<I: Iterator<Item = String>>(mut args: I) -> String {
             return arg;
         }
     }
-    "config.json".to_string()
+    "CPCluster_node/config/config.json".to_string()
 }
 
 fn parse_log_level<I: Iterator<Item = String>>(mut args: I) -> Option<log::LevelFilter> {
@@ -61,7 +61,10 @@ mod tests {
     #[test]
     fn default_path() {
         let args = vec!["prog".to_string()];
-        assert_eq!(parse_config_path(args.into_iter()), "config.json");
+        assert_eq!(
+            parse_config_path(args.into_iter()),
+            "CPCluster_node/config/config.json"
+        );
     }
 
     #[test]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The development roadmap lives in `docs/ROADMAP.md` and changes are tracked in
 ## Features
 
 - **Centralized Connection Management**: The master node manages node connections and assigns direct ports for inter-node communication.
-- **Dynamic Port Assignment**: Nodes request connections to other nodes through the master, which assigns available ports in the configurable range defined in the configuration file (`config.json` by default).
+- **Dynamic Port Assignment**: Nodes request connections to other nodes through the master, which assigns available ports in the configurable range defined in the configuration file (`CPCluster_masterNode/config/config.json` by default).
 - **Direct Node-to-Node Communication**: Nodes establish direct communication channels after being connected, allowing efficient data transfer with minimal latency.
 - **Token-based Authentication**: Nodes authenticate with the master using a unique token stored in a `join.json` file.
  - **Disconnect Handling**: The master node manages disconnections and releases ports when nodes leave the network.
@@ -92,13 +92,13 @@ OpenSSL development libraries manually before building.
    export CPCLUSTER_TOKEN=<token-from-master>
    ```
 3. **Copy `join.json` to nodes**: If not using the environment variable, each node must have a `join.json` file identical to the one in the master node directory. Copy this file to the `CPCluster_node` directory for each node that will join the network. Nodes read from `join.json` by default, or use `CPCLUSTER_JOIN` to specify a different path.
-4. **Edit `config.json`**: Both master and nodes read runtime options from `config.json` by default. You can pass a different file as the first command line argument. The configuration lets you tune the port range, failover timeout, master addresses and TLS certificates. Additional fields include `role` (`Worker`, `Disk`, `Internet`), `storage_dir`, `disk_space_mb`, `internet_ports` and `state_file`.
+4. **Edit the configuration file**: Both master and nodes read runtime options from `CPCluster_masterNode/config/config.json` and `CPCluster_node/config/config.json` by default. You can pass a different file as the first command line argument. The configuration lets you tune the port range, failover timeout, master addresses and TLS certificates. Additional fields include `role` (`Worker`, `Disk`, `Internet`), `storage_dir`, `disk_space_mb`, `internet_ports` and `state_file`.
 5. **Generate TLS certificates (optional)**: To secure traffic between nodes and the master, create a certificate for the master node and distribute it to all nodes:
    ```bash
    openssl req -x509 -newkey rsa:4096 -nodes -keyout master_key.pem \
        -out master_cert.pem -days 365 -subj "/CN=<master-ip>"
    ```
-   Set `cert_path` and `key_path` in `config.json` to these files and copy
+   Set `cert_path` and `key_path` in the configuration file to these files and copy
    `master_cert.pem` to each node, configuring the path in `ca_cert_path`.
 
 ### Running the Project
@@ -108,7 +108,7 @@ OpenSSL development libraries manually before building.
     cd CPCluster_masterNode
     cargo run -- <config-path> [--log-level <level>]
     ```
-    Replace `<config-path>` with the path to your configuration file if it is not `config.json`. The master node listens on port **55000** and manages all connection requests from nodes.
+    Replace `<config-path>` with the path to your configuration file if it is not `CPCluster_masterNode/config/config.json`. The master node listens on port **55000** and manages all connection requests from nodes.
    The `--log-level` flag controls verbosity (`error`, `warn`, `info`, `debug`, `trace`).
 
 2. **Start Normal Nodes**:

--- a/cpcluster_common/AGENTS.md
+++ b/cpcluster_common/AGENTS.md
@@ -1,6 +1,6 @@
 # cpcluster_common
 
-Shared types used across the CPCluster crates. The `Config` helper reads `config.json` and defaults when the file is missing.
+Shared types used across the CPCluster crates. The `Config` helper reads the config file from each crate's `config` directory and defaults when the file is missing.
 
 - Keep this crate lightweight as it is depended on by all others.
 - Any change here requires `cargo test` from the repository root.

--- a/cpcluster_common/README.md
+++ b/cpcluster_common/README.md
@@ -43,7 +43,7 @@ These types are `serde` serializable and are used by both the `cpcluster_mastern
 
 ## Configuration
 
-`Config` offers runtime configuration such as port ranges, failover timeout and the list of master nodes. A default configuration is returned when the specified file is missing. The master and node binaries look for `config.json` unless a different path is provided on the command line.
+`Config` offers runtime configuration such as port ranges, failover timeout and the list of master nodes. A default configuration is returned when the specified file is missing. The master and node binaries look for a config file in their respective `config` directories unless a different path is provided on the command line.
 
 Important fields include:
 


### PR DESCRIPTION
## Summary
- move config.json under each crate's config directory
- update default config paths in binaries and tests
- adjust sample config values
- refresh README and AGENTS notes to document new location

## Testing
- `cargo fmt`
- `cargo clippy --all-targets`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684df368f6208325b0d1776edf5eff24